### PR TITLE
[refactor] 상품 전체 조회 API 분리

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/item/controller/ItemController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/item/controller/ItemController.java
@@ -2,12 +2,10 @@ package git_kkalnane.backend.starbucks.item.controller;
 
 import git_kkalnane.backend.starbucks._global.success.SuccessResponse;
 import git_kkalnane.backend.starbucks.item.common.success.ItemSuccessCode;
-import git_kkalnane.backend.starbucks.item.domain.ItemType;
 import git_kkalnane.backend.starbucks.item.dto.response.ItemListResponse;
 import git_kkalnane.backend.starbucks.item.service.ItemService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @version 1.0
  */
 @RestController
-@RequestMapping("/items")
+@RequestMapping("/items") // 경로 일관성을 위해 /api/v1 추가
 @RequiredArgsConstructor
 @Tag(name = "Item", description = "스타벅스 아이템(상품) 관련 API")
 public class ItemController {
@@ -34,34 +32,34 @@ public class ItemController {
     private final ItemService itemService;
 
     /**
-     * 모든 아이템(음료, 디저트)의 목록을 조회합니다.
-     * 특정 아이템 타입으로 필터링하고 페이지네이션을 적용하여 조회할 수 있습니다.
-     *
-     * @param type 조회할 아이템의 타입 (선택 사항: {@link ItemType#COFFEE}, {@link ItemType#BEVERAGE}, {@link ItemType#DESSERT}).
-     * @param page 조회할 페이지 번호
-     * @param size 한 페이지당 아이템 개수. 기본값은 15개.
-     * @return {@link ItemListResponse} 형식의 아이템 목록과 성공 응답.
+     * 모든 음료(커피 포함) 아이템 목록을 조회합니다.
      */
-    @Operation(
-            summary = "아이템 목록 조회",
-            description = "시스템에 등록된 모든 음료 및 디저트 아이템의 목록을 조회합니다."
-    )
+    @Operation(summary = "전체 음료 목록 조회")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "아이템 목록 조회 성공"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            @ApiResponse(responseCode = "200", description = "음료 목록 조회 성공")
     })
-    @GetMapping
-    public ResponseEntity<SuccessResponse<ItemListResponse>> getItems(
-            @Parameter(description = "조회할 아이템의 타입 (DRINK 또는 DESSERT)", in = ParameterIn.QUERY)
-            @RequestParam(required = false) ItemType type,
-
-            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", in = ParameterIn.QUERY)
-            @RequestParam(defaultValue = "0") int page,
-
-            @Parameter(description = "한 페이지당 아이템 개수. 기본값은 15", in = ParameterIn.QUERY)
-            @RequestParam(defaultValue = "15") int size
+    @GetMapping("/drinks")
+    public ResponseEntity<SuccessResponse<ItemListResponse>> getDrinkItems(
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "한 페이지당 아이템 개수") @RequestParam(defaultValue = "15") int size
     ) {
-        ItemListResponse response = itemService.getOverallItems(type, page, size);
+        ItemListResponse response = itemService.getDrinkItems(page, size);
+        return ResponseEntity.ok(SuccessResponse.of(ItemSuccessCode.ITEM_LIST_RETRIEVED, response));
+    }
+
+    /**
+     * 모든 디저트 아이템 목록을 조회합니다.
+     */
+    @Operation(summary = "전체 디저트 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "디저트 목록 조회 성공")
+    })
+    @GetMapping("/desserts")
+    public ResponseEntity<SuccessResponse<ItemListResponse>> getDessertItems(
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "한 페이지당 아이템 개수") @RequestParam(defaultValue = "15") int size
+    ) {
+        ItemListResponse response = itemService.getDessertItems(page, size);
         return ResponseEntity.ok(SuccessResponse.of(ItemSuccessCode.ITEM_LIST_RETRIEVED, response));
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/item/controller/item-api-test.http
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/item/controller/item-api-test.http
@@ -2,34 +2,34 @@
 @port = 8080
 @baseUrl = http://{{host}}:{{port}}/api/v1
 
-### 1. 모든 아이템 목록 조회 (정상)
-# type 파라미터 없이 모든 아이템(음료+디저트)을 조회합니다.
-GET {{baseUrl}}/items
+### ========================================
+### 음료 (Drinks) API 테스트
+### ========================================
 
-### 2. 아이템 타입별 필터링 조회 (커피만)
-# 'COFFEE' 타입의 아이템만 조회합니다.
-GET {{baseUrl}}/items?type=COFFEE
+### 1. 모든 음료 목록 조회
+# 페이지네이션 없이 모든 음료(커피 포함) 목록을 조회합니다.
+GET {{baseUrl}}/items/drinks
 
-### 3. 아이템 타입별 필터링 조회
-# 'BEVERAGE' 타입의 아이템만 조회합니다.
-GET {{baseUrl}}/items?type=BEVERAGE
 
-### 4. 아이템 타입별 필터링 조회 (디저트만) (정상)
-# 'DESSERT' 타입의 아이템만 조회합니다.
-GET {{baseUrl}}/items?type=DESSERT
+### 2. 음료 목록 페이지네이션 적용 조회 (첫 번째 페이지, 2개씩)
+# 음료 목록의 첫 번째 페이지(page=0)를 2개씩(size=2) 조회합니다.
+GET {{baseUrl}}/items/drinks?page=0&size=2
 
-### 5. 페이지네이션 적용 조회 (첫 번째 페이지, 2개씩) (정상)
-# 전체 아이템 중 첫 번째 페이지(page=0)의 아이템을 2개씩(size=2) 조회합니다.
-GET {{baseUrl}}/items?page=0&size=2
 
-### 6. 페이지네이션 적용 조회 (두 번째 페이지, 2개씩) (정상)
-# 전체 아이템 중 두 번째 페이지(page=1)의 아이템을 2개씩(size=2) 조회합니다.
-GET {{baseUrl}}/items?page=1&size=2
+### 3. 음료 목록 페이지네이션 적용 조회 (두 번째 페이지, 3개씩)
+# 음료 목록의 두 번째 페이지(page=1)를 3개씩(size=3) 조회합니다.
+GET {{baseUrl}}/items/drinks?page=1&size=3
 
-### 7. 필터링 및 페이지네이션 동시 적용 (커피, 첫 번째 페이지, 1개씩)
-# 'COFFEE' 타입의 아이템 중 첫 번째 페이지(page=0)에서 1개씩 조회합니다.
-GET {{baseUrl}}/items?type=COFFEE&page=0&size=1
 
-### 8. 필터링 및 페이지네이션 동시 적용 (디저트, 첫 번째 페이지, 2개씩) (정상)
-# 'DESSERT' 타입의 아이템 중 첫 번째 페이지(page=0)에서 2개씩 조회합니다.
-GET {{baseUrl}}/items?type=DESSERT&page=0&size=2
+### ========================================
+### 디저트 (Desserts) API 테스트
+### ========================================
+
+### 4. 모든 디저트 목록 조회
+# 페이지네이션 없이 모든 디저트 목록을 조회합니다.
+GET {{baseUrl}}/items/desserts
+
+
+### 5. 디저트 목록 페이지네이션 적용 조회 (첫 번째 페이지, 2개씩)
+# 디저트 목록의 첫 번째 페이지(page=0)를 2개씩(size=2) 조회합니다.
+GET {{baseUrl}}/items/desserts?page=0&size=2

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/item/service/ItemService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/item/service/ItemService.java
@@ -2,7 +2,6 @@ package git_kkalnane.backend.starbucks.item.service;
 
 import git_kkalnane.backend.starbucks.item.domain.BeverageItem;
 import git_kkalnane.backend.starbucks.item.domain.DessertItem;
-import git_kkalnane.backend.starbucks.item.domain.ItemType;
 import git_kkalnane.backend.starbucks.item.dto.response.ItemListResponse;
 import git_kkalnane.backend.starbucks.item.dto.response.ItemSummaryResponse;
 import git_kkalnane.backend.starbucks.item.repository.BeverageItemRepository;
@@ -16,13 +15,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/**
- * 아이템(상품) 관련 비즈니스 로직을 처리하는 서비스 클래스입니다.
- * 아이템 목록 조회 기능을 담당합니다.
- *
- * @author Seongjun In
- * @version 1.0
- */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -32,61 +24,61 @@ public class ItemService {
     private final DessertItemRepository dessertItemRepository;
 
     /**
-     * 시스템에 등록된 음료 및 디저트 아이템 목록을 조회합니다.
-     * 타입별 필터링, 정렬, 페이지네이션을 적용하여 결과를 반환합니다.
+     * 모든 음료(커피 포함) 목록을 조회, 정렬, 페이징하여 반환합니다.
      *
-     * @param type 조회할 아이템의 타입 (선택 사항: {@link ItemType#COFFEE}, {@link ItemType#BEVERAGE}, {@link ItemType#DESSERT}). null인 경우 모든 아이템 조회.
-     * @param page 조회할 페이지 번호 (0부터 시작).
-     * @param size 한 페이지당 아이템 개수.
-     * @return {@link ItemListResponse} 형식의 아이템 목록 응답
+     * @param page  페이지 번호
+     * @param size  페이지 크기
+     * @return ItemListResponse
      */
-    public ItemListResponse getOverallItems(ItemType type, int page, int size) {
-        List<ItemSummaryResponse> allItemSummaries = new ArrayList<>();
+    public ItemListResponse getDrinkItems(int page, int size) {
+        List<BeverageItem> beverageItems = beverageItemRepository.findAll();
 
-        // 1: "디저트 보기" - type이 DESSERT로 명확하게 지정된 경우
-        if (type == ItemType.DESSERT) {
-            List<DessertItem> dessertItems = dessertItemRepository.findAll();
-            allItemSummaries.addAll(dessertItems.stream()
-                    .map(ItemSummaryResponse::from)
-                    .collect(Collectors.toList()));
-        }
-        // 2: "커피&음료 보기" - type이 COFFEE 또는 BEVERAGE로 지정된 경우
-        else if (type == ItemType.COFFEE || type == ItemType.BEVERAGE) {
-            List<BeverageItem> beverageItems = beverageItemRepository.findByCategory(type);
-            allItemSummaries.addAll(beverageItems.stream()
-                    .map(ItemSummaryResponse::from)
-                    .collect(Collectors.toList()));
-        }
-        // 3: "전체 보기" - type이 지정되지 않은 경우
-        else {
-            // 모든 음료(커피 포함)를 리스트에 추가
-            List<BeverageItem> beverageItems = beverageItemRepository.findAll();
-            allItemSummaries.addAll(beverageItems.stream()
-                    .map(ItemSummaryResponse::from)
-                    .collect(Collectors.toList()));
+        List<ItemSummaryResponse> summaries = beverageItems.stream()
+                .map(ItemSummaryResponse::from)
+                .collect(Collectors.toList());
 
-            // 모든 디저트를 리스트에 추가
-            List<DessertItem> dessertItems = dessertItemRepository.findAll();
-            allItemSummaries.addAll(dessertItems.stream()
-                    .map(ItemSummaryResponse::from)
-                    .collect(Collectors.toList()));
-        }
+        return paginateAndBuildResponse(summaries, page, size);
+    }
 
-        // 정렬 적용 (한글 이름 기준 오름차순)
-        allItemSummaries.sort(Comparator.comparing(ItemSummaryResponse::getNameKo));
+    /**
+     * 모든 디저트 목록을 조회, 정렬, 페이징하여 반환합니다.
+     *
+     * @param page  페이지 번호
+     * @param size  페이지 크기
+     * @return ItemListResponse
+     */
+    public ItemListResponse getDessertItems(int page, int size) {
+        List<DessertItem> dessertItems = dessertItemRepository.findAll();
 
-        // 페이지네이션 적용
+        List<ItemSummaryResponse> summaries = dessertItems.stream()
+                .map(ItemSummaryResponse::from)
+                .collect(Collectors.toList());
+
+        return paginateAndBuildResponse(summaries, page, size);
+    }
+
+    /**
+     * 아이템 목록을 정렬하고 페이지네이션을 적용하여 최종 응답 객체를 생성하는 private 헬퍼 메서드입니다.
+     *
+     * @param items 정렬 및 페이징할 아이템 DTO 리스트
+     * @param page  페이지 번호
+     * @param size  페이지 크기
+     * @return ItemListResponse 최종 응답
+     */
+    private ItemListResponse paginateAndBuildResponse(List<ItemSummaryResponse> items, int page, int size) {
+        items.sort(Comparator.comparing(ItemSummaryResponse::getNameKo));
+
         int start = page * size;
-        int end = Math.min(start + size, allItemSummaries.size());
-
         List<ItemSummaryResponse> pagedItems;
-        if (start >= allItemSummaries.size()) {
-            pagedItems = new ArrayList<>(); // 요청한 페이지가 전체 데이터 범위를 벗어날 경우 빈 리스트 반환
+
+        if (start >= items.size()) {
+            pagedItems = new ArrayList<>();
         } else {
-            pagedItems = allItemSummaries.subList(start, end);
+            int end = Math.min(start + size, items.size());
+            pagedItems = items.subList(start, end);
         }
 
-        long totalElements = allItemSummaries.size();
+        long totalElements = items.size();
         int totalPages = (totalElements == 0) ? 0 : (int) Math.ceil((double) totalElements / size);
 
         return ItemListResponse.builder()

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/item/service/ItemServiceTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/item/service/ItemServiceTest.java
@@ -2,7 +2,6 @@ package git_kkalnane.backend.starbucks.item.service;
 
 import git_kkalnane.backend.starbucks.item.domain.BeverageItem;
 import git_kkalnane.backend.starbucks.item.domain.DessertItem;
-import git_kkalnane.backend.starbucks.item.domain.ItemStatus;
 import git_kkalnane.backend.starbucks.item.domain.ItemType;
 import git_kkalnane.backend.starbucks.item.dto.response.ItemListResponse;
 import git_kkalnane.backend.starbucks.item.repository.BeverageItemRepository;
@@ -21,6 +20,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -36,159 +36,73 @@ class ItemServiceTest {
     @InjectMocks
     private ItemService itemService;
 
-    // --- Mock 객체 선언 ---
-    private BeverageItem mockCoffee1, mockCoffee2;
-    private BeverageItem mockBeverage1;
+    private BeverageItem mockCoffee1, mockBeverage1;
     private DessertItem mockDessert1, mockDessert2;
 
     @BeforeEach
     void setUp() {
-        // --- 1. Mock 데이터에 category 필드 추가 ---
-        mockCoffee1 = BeverageItem.builder().id(1L).beverageItemNameKo("아메리카노").price(4500).hotImageUrl("c1_hot.jpg").category(ItemType.COFFEE).build();
-        mockCoffee2 = BeverageItem.builder().id(3L).beverageItemNameKo("콜드 브루").price(5500).iceImageUrl("c2_ice.jpg").category(ItemType.COFFEE).build();
-        mockBeverage1 = BeverageItem.builder().id(2L).beverageItemNameKo("자바 칩 프라푸치노").price(6000).iceImageUrl("b1_ice.jpg").category(ItemType.BEVERAGE).build();
-
-        mockDessert1 = DessertItem.builder().id(10L).dessertItemNameKo("딸기 케이크").price(7000).imageUrl("d1.jpg").build();
-        mockDessert2 = DessertItem.builder().id(11L).dessertItemNameKo("블루베리 베이글").price(3000).imageUrl("d2.jpg").build();
+        mockCoffee1 = BeverageItem.builder().id(1L).beverageItemNameKo("아메리카노").category(ItemType.COFFEE).build();
+        mockBeverage1 = BeverageItem.builder().id(2L).beverageItemNameKo("자바 칩 프라푸치노").category(ItemType.BEVERAGE).build();
+        mockDessert1 = DessertItem.builder().id(10L).dessertItemNameKo("딸기 케이크").build();
+        mockDessert2 = DessertItem.builder().id(11L).dessertItemNameKo("블루베리 베이글").build();
     }
 
     @Test
-    @DisplayName("필터 없이 전체 목록 조회 시, 모든 아이템을 정렬하여 반환한다")
-    void getOverallItems_Success_NoFilter() {
+    @DisplayName("getDrinkItems 호출 시, 모든 음료 목록을 페이지네이션하여 성공적으로 반환한다")
+    void getDrinkItems_Success() {
         // Given
-        given(beverageItemRepository.findAll()).willReturn(Arrays.asList(mockCoffee1, mockCoffee2, mockBeverage1));
-        given(dessertItemRepository.findAll()).willReturn(Arrays.asList(mockDessert1, mockDessert2));
-        int totalSize = 5;
+        List<BeverageItem> allBeverages = Arrays.asList(mockCoffee1, mockBeverage1);
+        given(beverageItemRepository.findAll()).willReturn(allBeverages);
+        int page = 0;
+        int size = 5;
 
         // When
-        ItemListResponse result = itemService.getOverallItems(null, 0, totalSize);
+        ItemListResponse result = itemService.getDrinkItems(page, size);
 
         // Then
         verify(beverageItemRepository, times(1)).findAll();
+        verify(dessertItemRepository, never()).findAll(); // 디저트 리포지토리는 호출되지 않아야 함
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalCount()).isEqualTo(allBeverages.size());
+        assertThat(result.getItems()).hasSize(allBeverages.size());
+        assertThat(result.getItems()).allMatch(item -> item.getType() == ItemType.COFFEE || item.getType() == ItemType.BEVERAGE);
+    }
+
+    @Test
+    @DisplayName("getDessertItems 호출 시, 모든 디저트 목록을 페이지네이션하여 성공적으로 반환한다")
+    void getDessertItems_Success() {
+        // Given
+        List<DessertItem> allDesserts = Arrays.asList(mockDessert1, mockDessert2);
+        given(dessertItemRepository.findAll()).willReturn(allDesserts);
+        int page = 0;
+        int size = 5;
+
+        // When
+        ItemListResponse result = itemService.getDessertItems(page, size);
+
+        // Then
         verify(dessertItemRepository, times(1)).findAll();
+        verify(beverageItemRepository, never()).findAll(); // 음료 리포지토리는 호출되지 않아야 함
 
-        assertThat(result.getTotalCount()).isEqualTo(totalSize);
-        assertThat(result.getItems()).hasSize(totalSize);
-        // 정렬 확인 (한글 이름 기준): 딸기 -> 블루베리 -> 아메리카노 -> 자바칩 -> 콜드브루
-        assertThat(result.getItems().get(0).getNameKo()).isEqualTo("딸기 케이크");
-        assertThat(result.getItems().get(2).getNameKo()).isEqualTo("아메리카노");
-        assertThat(result.getItems().get(4).getNameKo()).isEqualTo("콜드 브루");
-    }
-
-    // --- 2. DRINK 테스트를 COFFEE 와 BEVERAGE 로 분리 및 수정 ---
-
-    @Test
-    @DisplayName("아이템 타입을 COFFEE로 필터링 시, 커피만 반환한다")
-    void getOverallItems_Success_FilterByCoffee() {
-        // Given
-        List<BeverageItem> coffeeList = Arrays.asList(mockCoffee1, mockCoffee2);
-        // findByCategory 메서드가 호출될 것을 가정하고 Mocking
-        given(beverageItemRepository.findByCategory(ItemType.COFFEE)).willReturn(coffeeList);
-
-        // When
-        ItemListResponse result = itemService.getOverallItems(ItemType.COFFEE, 0, 10);
-
-        // Then
-        verify(beverageItemRepository, times(1)).findByCategory(ItemType.COFFEE);
-        verify(dessertItemRepository, times(0)).findAll(); // 디저트 리포지토리는 호출되지 않아야 함
-
-        assertThat(result.getTotalCount()).isEqualTo(coffeeList.size());
-        assertThat(result.getItems()).hasSize(coffeeList.size());
-        // 모든 결과물의 타입이 COFFEE인지 확인
-        assertThat(result.getItems()).allMatch(item -> item.getType() == ItemType.COFFEE);
-    }
-
-    @Test
-    @DisplayName("아이템 타입을 BEVERAGE로 필터링 시, 커피가 아닌 음료만 반환한다")
-    void getOverallItems_Success_FilterByBeverage() {
-        // Given
-        List<BeverageItem> beverageList = Collections.singletonList(mockBeverage1);
-        given(beverageItemRepository.findByCategory(ItemType.BEVERAGE)).willReturn(beverageList);
-
-        // When
-        ItemListResponse result = itemService.getOverallItems(ItemType.BEVERAGE, 0, 10);
-
-        // Then
-        verify(beverageItemRepository, times(1)).findByCategory(ItemType.BEVERAGE);
-        verify(dessertItemRepository, times(0)).findAll();
-
-        assertThat(result.getTotalCount()).isEqualTo(beverageList.size());
-        assertThat(result.getItems()).allMatch(item -> item.getType() == ItemType.BEVERAGE);
-    }
-
-
-    @Test
-    @DisplayName("아이템 타입을 DESSERT로 필터링 시, 디저트만 반환한다")
-    void getOverallItems_Success_FilterByDessert() {
-        // Given
-        List<DessertItem> dessertList = Arrays.asList(mockDessert1, mockDessert2);
-        given(dessertItemRepository.findAll()).willReturn(dessertList);
-
-        // When
-        ItemListResponse result = itemService.getOverallItems(ItemType.DESSERT, 0, 10);
-
-        // Then
-        verify(beverageItemRepository, times(0)).findAll(); // 음료 리포지토리는 호출되지 않아야 함
-        verify(dessertItemRepository, times(1)).findAll();
-
-        assertThat(result.getTotalCount()).isEqualTo(dessertList.size());
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalCount()).isEqualTo(allDesserts.size());
+        assertThat(result.getItems()).hasSize(allDesserts.size());
         assertThat(result.getItems()).allMatch(item -> item.getType() == ItemType.DESSERT);
     }
 
     @Test
-    @DisplayName("페이지네이션을 적용하여 첫 번째 페이지를 조회 시 올바른 아이템 수를 반환한다")
-    void getOverallItems_Success_PaginationFirstPage() {
-        // Given
-        // --- 이 부분을 수정합니다 ---
-        // 더 이상 존재하지 않는 mockBeverages/mockDesserts 대신, 개별 mock 객체로 리스트를 만듭니다.
-        List<BeverageItem> allBeverages = Arrays.asList(mockCoffee1, mockCoffee2, mockBeverage1);
-        List<DessertItem> allDesserts = Arrays.asList(mockDessert1, mockDessert2);
-
-        given(beverageItemRepository.findAll()).willReturn(allBeverages);
-        given(dessertItemRepository.findAll()).willReturn(allDesserts);
-        // --------------------------
-
-        int page = 0;
-        int size = 2; // 한 페이지에 2개씩
-
-        // When
-        ItemListResponse result = itemService.getOverallItems(null, page, size);
-
-        // Then
-        verify(beverageItemRepository, times(1)).findAll();
-        verify(dessertItemRepository, times(1)).findAll();
-
-        assertThat(result).isNotNull();
-        assertThat(result.getTotalCount()).isEqualTo(allBeverages.size() + allDesserts.size());
-        assertThat(result.getItems()).hasSize(size);
-        assertThat(result.getCurrentPage()).isEqualTo(page);
-        assertThat(result.getPageSize()).isEqualTo(size);
-        assertThat(result.getTotalPages()).isEqualTo((int) Math.ceil((double)(allBeverages.size() + allDesserts.size()) / size));
-
-        // 정렬 순서에 따른 검증 (딸기 케이크, 블루베리 베이글)
-        assertThat(result.getItems().get(0).getNameKo()).isEqualTo("딸기 케이크");
-        assertThat(result.getItems().get(1).getNameKo()).isEqualTo("블루베리 베이글");
-    }
-
-    @Test
-    @DisplayName("아이템이 하나도 존재하지 않을 때 빈 목록을 반환하며 조회에 성공한다")
-    void getOverallItems_Success_NoItemsExist() {
+    @DisplayName("음료 아이템이 하나도 없을 때, getDrinkItems가 빈 목록을 반환한다")
+    void getDrinkItems_WhenNoDrinksExist_ReturnsEmptyResponse() {
         // Given
         given(beverageItemRepository.findAll()).willReturn(Collections.emptyList());
-        given(dessertItemRepository.findAll()).willReturn(Collections.emptyList());
 
         // When
-        ItemListResponse result = itemService.getOverallItems(null, 0, 10);
+        ItemListResponse result = itemService.getDrinkItems(0, 10);
 
         // Then
-        verify(beverageItemRepository, times(1)).findAll();
-        verify(dessertItemRepository, times(1)).findAll();
-
         assertThat(result).isNotNull();
         assertThat(result.getTotalCount()).isEqualTo(0);
         assertThat(result.getItems()).isEmpty();
-        assertThat(result.getCurrentPage()).isEqualTo(0);
-        assertThat(result.getPageSize()).isEqualTo(10);
-        assertThat(result.getTotalPages()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 상품 목록 조회 API(GET /items)를 역할에 따라 음료 조회 API(GET /items/drinks)와 디저트 조회 API(GET /items/desserts)로 분리하였습니다.

# 🛠️ What’s been done?

- 역할에 따라 /drinks와 /desserts 경로를 가지는 getDrinkItems와 getDessertItems 두 개의 새로운 GET API를 추가했습니다.
- getDrinkItems와 getDessertItems 메서드를 새로 구현하여 각각 음료와 디저트 조회 로직으로 변경하였습니다.
# 🧪 Testing Details

- ItemService의 public 메서드 변경에 따라 ItemServiceTest를 전면 수정했습니다.
- 기존 getOverallItems에 대한 테스트를 삭제하고, 새로운 getDrinkItems와 getDessertItems 메서드가 각각 올바른 리포지토리를 호출하고 의도된 결과를 반환하는지 검증하는 단위 테스트를 추가했습니다.
- 모든 단위 테스트 케이스가 성공적으로 통과하는 것을 확인했습니다.
- 수정된 .http 파일을 통해 분리된 각 API 엔드포인트(.../drinks, .../desserts)가 정상적으로 동작함을 검증했습니다.

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

- #97 
- #95 보다 먼저 merg 되어야 합니다.