### PR TITLE
[feat] 알림 목록 조회 구현

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/common/exception/NotificationErrorCode.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/common/exception/NotificationErrorCode.java
@@ -1,6 +1,6 @@
 package git_kkalnane.backend.starbucks.notification.common.exception;
 
-import git_kkalnane.backend.starbucks.global.error.core.ErrorCode;
+import git_kkalnane.backend.starbucks._global.error.core.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/common/exception/NotificationException.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/common/exception/NotificationException.java
@@ -1,8 +1,7 @@
 package git_kkalnane.backend.starbucks.notification.common.exception;
 
 
-import git_kkalnane.backend.starbucks.auth.common.exception.AuthErrorCode;
-import git_kkalnane.backend.starbucks.global.error.core.BaseException;
+import git_kkalnane.backend.starbucks._global.error.core.BaseException;
 
 public class NotificationException extends BaseException {
 

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/common/success/NotificationSuccessCode.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/common/success/NotificationSuccessCode.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum NotificationSuccessCode implements SuccessCode {
     NOTIFICATION_SUBSCRIBED(HttpStatus.CREATED, "알림 구독에 성공하였습니다. %s"),
     NOTIFICATION_SUBSCRIPTION_RETRIEVED(HttpStatus.OK, "알림 구독 목록이 성공적으로 조회되었습니다."),
+    NOTIFICATION_RETRIEVED(HttpStatus.OK, "알림 목록이 성공적으로 조회되었습니다."),
     NOTIFICATION_DELIVERED(HttpStatus.OK, "알림이 성공적으로 전송되었습니다.")
     ;
 

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/common/success/NotificationSuccessCode.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/common/success/NotificationSuccessCode.java
@@ -1,6 +1,6 @@
 package git_kkalnane.backend.starbucks.notification.common.success;
 
-import git_kkalnane.backend.starbucks.global.success.SuccessCode;
+import git_kkalnane.backend.starbucks._global.success.SuccessCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/controller/NotificationController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/controller/NotificationController.java
@@ -1,7 +1,7 @@
 package git_kkalnane.backend.starbucks.notification.controller;
 
 
-import git_kkalnane.backend.starbucks.global.success.SuccessResponse;
+import git_kkalnane.backend.starbucks._global.success.SuccessResponse;
 import git_kkalnane.backend.starbucks.notification.common.success.NotificationSuccessCode;
 import git_kkalnane.backend.starbucks.notification.domain.NotificationTargetType;
 import git_kkalnane.backend.starbucks.notification.dto.request.NotificationSendRequest;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/controller/NotificationController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/controller/NotificationController.java
@@ -9,6 +9,9 @@ import git_kkalnane.backend.starbucks.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -47,6 +50,22 @@ public class NotificationController {
                 NotificationSuccessCode.NOTIFICATION_DELIVERED));
     }
 
+    @GetMapping
+    @Operation(summary = "멤버 알림 목록 조회"
+            , description = "멤버의 알림 목록을 조회합니다. 조회되지 않으면 빈 리스트를 반환합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "알림 목록 조회 완료"
+    )
+    public ResponseEntity<SuccessResponse<?>> fetchNotifications(
+            @RequestAttribute Long memberId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return ResponseEntity.ok(SuccessResponse.of(
+                NotificationSuccessCode.NOTIFICATION_SUBSCRIPTION_RETRIEVED
+                , notificationService.fetchNotificationsByMemberId(memberId, pageable)));
+    }
+
 
     @GetMapping(value = "/subscribe/status")
     @Operation(summary = "멤버 알림 구독 현황 목록 조회"
@@ -58,6 +77,6 @@ public class NotificationController {
     public ResponseEntity<SuccessResponse<?>> fetchSubscribeList(@RequestAttribute Long memberId) {
         return ResponseEntity.ok(SuccessResponse.of(
                 NotificationSuccessCode.NOTIFICATION_SUBSCRIPTION_RETRIEVED
-                ,notificationService.getEmitters(memberId, NotificationTargetType.CUSTOMER)));
+                , notificationService.getEmitters(memberId, NotificationTargetType.CUSTOMER)));
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/controller/notification.http
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/controller/notification.http
@@ -31,3 +31,10 @@ Authorization: Bearer {{accessToken}}
 %}
 GET http://localhost:8080/api/v1/notifications/subscribe/status
 Authorization: Bearer {{accessToken}}
+
+### 알림 구독 현황 목록 조회 (SseEmitter 상태 조회)
+< {%
+    request.variables.set("accessToken", "")
+%}
+GET http://localhost:8080/api/v1/notifications
+Authorization: Bearer {{accessToken}}

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/domain/Notification.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/domain/Notification.java
@@ -53,9 +53,8 @@ public class Notification extends BaseTimeEntity {
     private NotificationType notificationType;
 
 
-    public NotificationResponse toDto(String emitterId) {
+    public NotificationResponse toDto() {
         return NotificationResponse.builder()
-                .emitterId(emitterId)
                 .eventId(event.value())
                 .message(message)
                 .title(title)

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/domain/Notification.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/domain/Notification.java
@@ -1,7 +1,7 @@
 package git_kkalnane.backend.starbucks.notification.domain;
 
 
-import git_kkalnane.backend.starbucks.global.entity.BaseTimeEntity;
+import git_kkalnane.backend.starbucks._global.entity.BaseTimeEntity;
 import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationEvent;
 import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationReceiver;
 import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationSender;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/dto/response/NotificationResponse.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/dto/response/NotificationResponse.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 @Builder
 public class NotificationResponse {
     private String eventId;
-    private String emitterId;
     private Long senderId;
     private Long receiverId;
     private String title;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/dto/response/NotificationsResponse.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/dto/response/NotificationsResponse.java
@@ -1,0 +1,17 @@
+package git_kkalnane.backend.starbucks.notification.dto.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class NotificationsResponse {
+    private List<NotificationResponse> notifications;
+    private long total;
+    private int page;
+    private int pageSize;
+    private int totalPages;
+}

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/repository/NotificationRepository.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/repository/NotificationRepository.java
@@ -1,7 +1,10 @@
 package git_kkalnane.backend.starbucks.notification.repository;
 
 import git_kkalnane.backend.starbucks.notification.domain.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification,Long> {
+    Page<Notification> findAllByReceiverId(Long receiverId, Pageable pageable);
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/service/NotificationService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/service/NotificationService.java
@@ -11,9 +11,12 @@ import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationReceive
 import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationSender;
 import git_kkalnane.backend.starbucks.notification.dto.request.NotificationSendRequest;
 import git_kkalnane.backend.starbucks.notification.dto.response.NotificationResponse;
+import git_kkalnane.backend.starbucks.notification.dto.response.NotificationsResponse;
 import git_kkalnane.backend.starbucks.notification.repository.EmitterRepository;
 import git_kkalnane.backend.starbucks.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -54,6 +57,21 @@ public class NotificationService {
         return emitter;
     }
 
+    public NotificationsResponse fetchNotificationsByMemberId(Long memberId, Pageable pageable){
+        Page<Notification> notifications = notificationRepository.findAllByReceiverId(memberId, pageable);
+
+        return NotificationsResponse.builder()
+                .notifications(
+                        notifications.stream()
+                                .map(Notification::toDto)
+                                .toList()
+                )
+                .total(notifications.getTotalElements())
+                .page(notifications.getNumber())
+                .pageSize(notifications.getSize())
+                .totalPages(notifications.getTotalPages()).build();
+    }
+
     @Transactional
     public void sendNotification(String title, String message,
                                  Long senderId, Long receiverId,
@@ -80,7 +98,7 @@ public class NotificationService {
         // TODO: 트랜잭션 실패로 인한 롤백 처리 등의 안정성 고려하기
         emitters.forEach(
                 (key, emitter) -> {
-                    NotificationResponse responseDto = notification.toDto(key);
+                    NotificationResponse responseDto = notification.toDto();
 
                     emitterRepository.saveEventCache(key, notification);
                     send(emitter, event, key, responseDto);

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/NotificationServiceTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/NotificationServiceTest.java
@@ -2,9 +2,16 @@ package git_kkalnane.backend.starbucks.notification;
 
 import git_kkalnane.backend.starbucks.notification.common.exception.NotificationErrorCode;
 import git_kkalnane.backend.starbucks.notification.common.exception.NotificationException;
+import git_kkalnane.backend.starbucks.notification.domain.Notification;
 import git_kkalnane.backend.starbucks.notification.domain.NotificationTargetType;
 import git_kkalnane.backend.starbucks.notification.domain.NotificationType;
+import git_kkalnane.backend.starbucks.notification.domain.SseEmitterId;
+import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationEvent;
+import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationReceiver;
+import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationSender;
 import git_kkalnane.backend.starbucks.notification.dto.request.NotificationSendRequest;
+import git_kkalnane.backend.starbucks.notification.dto.response.NotificationResponse;
+import git_kkalnane.backend.starbucks.notification.dto.response.NotificationsResponse;
 import git_kkalnane.backend.starbucks.notification.repository.EmitterRepository;
 import git_kkalnane.backend.starbucks.notification.repository.NotificationRepository;
 import git_kkalnane.backend.starbucks.notification.service.NotificationService;
@@ -15,9 +22,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,6 +81,89 @@ class NotificationServiceTest {
             assertThatThrownBy(() -> notificationService.subscribe(receiverId, targetType))
                     .isInstanceOf(NotificationException.class)
                     .hasMessageContaining(NotificationErrorCode.INVALID_NOTIFICATION_TYPE.getMessage(targetType));
+        }
+    }
+
+    @Nested
+    @DisplayName("fetchNotificationsByMemberId() 테스트")
+    class FetchNotificationsByMemberIdTest {
+        @Test
+        @DisplayName("성공: 알림 목록 조회")
+        void fetchNotificationsByMemberId_success() {
+            // given
+            Long memberId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+            
+            // 테스트용 알림 데이터 생성
+            Notification notification1 = createTestNotification(1L, memberId, "제목1", "메시지1");
+            Notification notification2 = createTestNotification(2L, memberId, "제목2", "메시지2");
+            List<Notification> notificationList = List.of(notification1, notification2);
+            
+            Page<Notification> notificationPage = new PageImpl<>(
+                    notificationList, 
+                    pageable, 
+                    2L
+            );
+            
+            given(notificationRepository.findAllByReceiverId(memberId, pageable))
+                    .willReturn(notificationPage);
+
+            // when
+            NotificationsResponse result = notificationService.fetchNotificationsByMemberId(memberId, pageable);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getNotifications()).hasSize(2);
+            assertThat(result.getTotal()).isEqualTo(2L);
+            assertThat(result.getPage()).isEqualTo(0);
+            assertThat(result.getPageSize()).isEqualTo(10);
+            assertThat(result.getTotalPages()).isEqualTo(1);
+            
+            verify(notificationRepository, times(1)).findAllByReceiverId(memberId, pageable);
+        }
+
+        @Test
+        @DisplayName("성공: 빈 알림 목록 조회")
+        void fetchNotificationsByMemberId_emptyList() {
+            // given
+            Long memberId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+            
+            Page<Notification> emptyPage = new PageImpl<>(
+                    Collections.emptyList(), 
+                    pageable, 
+                    0L
+            );
+            
+            given(notificationRepository.findAllByReceiverId(memberId, pageable))
+                    .willReturn(emptyPage);
+
+            // when
+            NotificationsResponse result = notificationService.fetchNotificationsByMemberId(memberId, pageable);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getNotifications()).isEmpty();
+            assertThat(result.getTotal()).isEqualTo(0L);
+            assertThat(result.getPage()).isEqualTo(0);
+            assertThat(result.getPageSize()).isEqualTo(10);
+            assertThat(result.getTotalPages()).isEqualTo(0);
+            
+            verify(notificationRepository, times(1)).findAllByReceiverId(memberId, pageable);
+        }
+
+        private Notification createTestNotification(Long id, Long receiverId, String title, String message) {
+            return Notification.builder()
+                    .id(id)
+                    .title(title)
+                    .message(message)
+                    .event(NotificationEvent.of(receiverId, NotificationTargetType.CUSTOMER, NotificationType.SUBSCRIBE))
+                    .receiver(NotificationReceiver.of(receiverId))
+                    .sender(NotificationSender.of(1L))
+                    .notificationTargetType(NotificationTargetType.CUSTOMER)
+                    .notificationType(NotificationType.SUBSCRIBE)
+                    .isRead(false)
+                    .build();
         }
     }
 


### PR DESCRIPTION
# 🚀 What’s this PR about?

- **작업 내용 요약:** 알림 목록 조회 구현

# 🛠️ What’s been done?

- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  - `_global` 패키지를 import 하도록 변경했습니다.
  - 알림 목록 조회 API 구현 하였습니다.
  - `NotificationReceiver`를 기준으로 조회할 수 있도록 구현하였습니다.
  - 응답 필드는 다음과 같이 작성하였으니 확인 부탁드립니다. 실제 구현은 주문번호, 매장, 닉네임 등으로 구성할 예정입니다.
  ```json
  {
                "eventId": "CUSTOMER_1_ORDER_SET_1750399284358",
                "senderId": 1,
                "receiverId": 1,
                "title": "주문 완료",
                "message": "주문이 완료 되었습니다.",
                "notificationType": "ORDER_SET",
                "notificationTargetType": "CUSTOMER"
  }

# 🧪 Testing Details

- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 알림 목록 페이지네이션 조회 테스트 코드 작성(이후 PR을 통해 명시)

# 👀 Checkpoints for Reviewers
응답 필드 관련하여 의견이 있으시다면 말씀 부탁 드리겠습니다.

# 🎯 Related Issues

closes #38 
