### PR TITLE
[feat] 주문 내용 저장 기능 구현

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/controller/OrderController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/controller/OrderController.java
@@ -5,6 +5,7 @@ import git_kkalnane.backend.starbucks._global.success.SuccessResponse;
 import git_kkalnane.backend.starbucks.order.common.success.OrderSuccessCode;
 import git_kkalnane.backend.starbucks.order.domain.Order;
 import git_kkalnane.backend.starbucks.order.dto.request.CreateRequest;
+import git_kkalnane.backend.starbucks.order.dto.response.CreateResponse;
 import git_kkalnane.backend.starbucks.order.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -38,10 +39,10 @@ public class OrderController {
     public ResponseEntity<SuccessResponse> createOrder(@Valid @RequestBody CreateRequest request) {
 
         Long memberId = 1L;
-        orderService.createOrder(request, memberId);
+        CreateResponse createResponse = orderService.createOrder(request, memberId);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(SuccessResponse.of(OrderSuccessCode.ORDER_SUCCESS_CREATED, request));
+                .body(SuccessResponse.of(OrderSuccessCode.ORDER_SUCCESS_CREATED, createResponse));
     }
 
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/Order.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/Order.java
@@ -51,7 +51,7 @@ public class Order extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
 
     public void addOrderItem(OrderItem item) {

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/request/OrderItemRequest.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/request/OrderItemRequest.java
@@ -23,7 +23,8 @@ public record OrderItemRequest(
         BeverageTemperatureOption beverageTemperatureOption,
         List<ItemOptionRequest> options,
         int itemPrice,
-        int totalPrice
+        int totalPrice,
+        int quantity
         ) {
 
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/service/OrderService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/service/OrderService.java
@@ -14,7 +14,6 @@ import git_kkalnane.backend.starbucks.order.dto.request.CreateRequest;
 import git_kkalnane.backend.starbucks.order.dto.request.OrderItemRequest;
 import git_kkalnane.backend.starbucks.order.dto.response.CreateResponse;
 import git_kkalnane.backend.starbucks.order.repository.OrderDailyCounterRepository;
-import git_kkalnane.backend.starbucks.order.repository.OrderItemRepository;
 import git_kkalnane.backend.starbucks.order.repository.OrderRepository;
 import git_kkalnane.backend.starbucks.store.domain.Store;
 import git_kkalnane.backend.starbucks.store.repository.StoreRepository;
@@ -30,6 +29,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderService {
 
 
@@ -39,7 +39,6 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final BeverageItemRepository beverageItemRepository;
     private final DessertItemRepository dessertItemRepository;
-    private final OrderItemRepository orderItemRepository;
 
     /**
      * 주문생성 로직
@@ -79,15 +78,12 @@ public class OrderService {
             order.addOrderItem(item);
         }
 
-        orderRepository.save(order);
-        orderItemRepository.saveAll(orderItems);
-
-
+        Order savedOrder = orderRepository.save(order);
 
         return new CreateResponse(
                 200,
                 "주문이 성공적으로 생성되었습니다.",
-                order.getId()
+                savedOrder.getId()
         );
     }
 
@@ -99,14 +95,16 @@ public class OrderService {
      */
 
     private OrderItem validateAndCreateOrderItems(OrderItemRequest request) {
+        int orderQuantity = request.quantity();
+
         if (request.itemType() == ItemType.DRINK) {
             BeverageItem item = beverageItemRepository.findById(request.itemId())
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 음료입니다."));
 
             return OrderItem.builder()
                     .itemName(item.getBeverageItemNameKo())
-                    .unitPrice(request.itemPrice())
-                    .orderItemQuantity(1)
+                    .unitPrice(item.getPrice())
+                    .orderItemQuantity(orderQuantity)
                     .beverageItem(item)
                     .build();
 
@@ -116,8 +114,8 @@ public class OrderService {
 
             return OrderItem.builder()
                     .itemName(item.getDessertItemNameKo())
-                    .unitPrice(request.itemPrice())
-                    .orderItemQuantity(1)
+                    .unitPrice(item.getPrice())
+                    .orderItemQuantity(orderQuantity)
                     .dessertItem(item)
                     .build();
         }

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/order/OrderCreateTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/order/OrderCreateTest.java
@@ -6,6 +6,7 @@ import git_kkalnane.backend.starbucks.item.domain.beverage.enums.BeverageSizeOpt
 import git_kkalnane.backend.starbucks.item.domain.beverage.enums.BeverageTemperatureOption;
 import git_kkalnane.backend.starbucks.item.domain.dessert.DessertItem;
 import git_kkalnane.backend.starbucks.item.repository.BeverageItemRepository;
+import git_kkalnane.backend.starbucks.item.repository.DessertItemRepository;
 import git_kkalnane.backend.starbucks.member.domain.Member;
 import git_kkalnane.backend.starbucks.member.repository.MemberRepository;
 import git_kkalnane.backend.starbucks.order.domain.*;
@@ -14,7 +15,6 @@ import git_kkalnane.backend.starbucks.order.dto.request.ItemOptionRequest;
 import git_kkalnane.backend.starbucks.order.dto.request.OrderItemRequest;
 import git_kkalnane.backend.starbucks.order.dto.response.CreateResponse;
 import git_kkalnane.backend.starbucks.order.repository.OrderDailyCounterRepository;
-import git_kkalnane.backend.starbucks.order.repository.OrderItemRepository;
 import git_kkalnane.backend.starbucks.order.repository.OrderRepository;
 import git_kkalnane.backend.starbucks.store.domain.Store;
 import git_kkalnane.backend.starbucks.store.repository.StoreRepository;
@@ -25,9 +25,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,9 +43,8 @@ class OrderCreateTest {
     @Mock private StoreRepository storeRepository;
     @Mock private MemberRepository memberRepository;
     @Mock private BeverageItemRepository beverageItemRepository;
+    @Mock private DessertItemRepository dessertItemRepository;
     @Mock private OrderRepository orderRepository;
-    @Mock private OrderItemRepository orderItemRepository;
-
 
     @InjectMocks private OrderService orderService;
 
@@ -56,25 +57,149 @@ class OrderCreateTest {
     void 정보_세팅() {
         mockStore = Store.builder().id(1L).build();
         mockMember = Member.builder().id(1L).build();
-        mockBeverage = BeverageItem.builder().id(101L).beverageItemNameKo("아이스 아메리카노").build();
-        mockDessert = DessertItem.builder().id(201L).dessertItemNameKo("치즈케이크").build();
+        mockBeverage = BeverageItem.builder().id(101L).beverageItemNameKo("아이스 아메리카노").price(4500).build();
+        mockDessert = DessertItem.builder().id(201L).dessertItemNameKo("치즈케이크").price(5500).build();
     }
 
     @Test
     @DisplayName("정상적인 주문 생성 테스트")
     void createOrder_Success() {
         // Given
-        List<ItemOptionRequest> options = List.of(
-                new ItemOptionRequest(1L, "WHIPPED_CREAM", false, 1, 500, 1)
+        int requestedQuantity = 2;
+        int beveragePrice = mockBeverage.getPrice();
+
+        List<ItemOptionRequest> options = new ArrayList<>();
+
+        List<OrderItemRequest> orderItems = List.of(
+                new OrderItemRequest(
+                        mockBeverage.getId(),
+                        ItemType.DRINK,
+                        BeverageSizeOption.TALL,
+                        BeverageTemperatureOption.HOT,
+                        options,
+                        beveragePrice,
+                        beveragePrice * requestedQuantity,
+                        requestedQuantity
+                )
+        );
+        CreateRequest request = new CreateRequest(
+                mockStore.getId(),
+                PickupType.STORE_PICKUP,
+                orderItems.get(0).totalPrice(),
+                OrderStatus.PLACED,
+                LocalDateTime.now().plusMinutes(10),
+                orderItems
         );
 
-        List<OrderItemRequest> orderItems = List.of(new OrderItemRequest(mockBeverage.getId(), ItemType.DRINK, BeverageSizeOption.TALL, BeverageTemperatureOption.HOT, options, 4100, 5000 ));
-        CreateRequest request = new CreateRequest(mockStore.getId(), PickupType.STORE_PICKUP, 5000, OrderStatus.PLACED, LocalDateTime.now().plusMinutes(10), orderItems );
+        given(storeRepository.findById(mockStore.getId())).willReturn(Optional.of(mockStore));
+        given(memberRepository.findById(mockMember.getId())).willReturn(Optional.of(mockMember));
+        given(beverageItemRepository.findById(mockBeverage.getId())).willReturn(Optional.of(mockBeverage));
+        given(orderDailyCounterRepository.findById(any(LocalDate.class)))
+                .willReturn(Optional.of(new OrderDailyCounter(LocalDate.now(), 0))); // 처음에는 0, increment 후 1
+        given(orderDailyCounterRepository.save(any(OrderDailyCounter.class)))
+                .willAnswer(invocation -> {
+                    OrderDailyCounter counter = invocation.getArgument(0);
+                    return counter; // 전달된 객체를 그대로 반환
+                });
+        given(orderRepository.save(any(Order.class))).willAnswer(invocation -> {
+        Order order = invocation.getArgument(0);
+            if (order.getId() == null) {
+                order = Order.builder()
+                        .id(1L)
+                        .orderNumber(order.getOrderNumber())
+                        .store(order.getStore())
+                        .member(order.getMember())
+                        .orderExpectedPickupTime(order.getOrderExpectedPickupTime())
+                        .orderStatus(order.getOrderStatus())
+                        .orderItems(order.getOrderItems())
+                        .orderTotalPrice(order.getOrderTotalPrice())
+                        .pickupType(order.getPickupType())
+                        .build();
+            }
+            for (OrderItem item : order.getOrderItems()) {
+                if (item.getOrder() == null) {
+                    item.setOrder(order);
+                }
+            }
+            return order;
+        });
+        // When
+        CreateResponse response = orderService.createOrder(request, mockMember.getId());
+
+        // Then
+        assertThat(response.httpStatus()).isEqualTo(200);
+        assertThat(response.message()).contains("성공");
+        assertThat(response.orderId()).isNotNull();
+        assertThat(response.orderId()).isEqualTo(1L);
+
+        verify(storeRepository, times(1)).findById(mockStore.getId());
+        verify(memberRepository, times(1)).findById(mockMember.getId());
+        verify(beverageItemRepository, times(1)).findById(mockBeverage.getId());
+        verify(orderDailyCounterRepository, times(1)).findById(any(LocalDate.class));
+        verify(orderDailyCounterRepository, times(1)).save(any(OrderDailyCounter.class));
+        verify(orderRepository, times(1)).save(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("정상적인 디저트 주문 생성 테스트")
+    void createOrder_DessertSuccess() {
+        // Given
+        int requestedQuantity = 1;
+        int dessertPrice = mockDessert.getPrice();
+        List<ItemOptionRequest> options = new ArrayList<>();
+
+        List<OrderItemRequest> orderItems = List.of(
+                new OrderItemRequest(
+                        mockDessert.getId(),
+                        ItemType.DESSERT,
+                        null,
+                        null,
+                        options,
+                        dessertPrice,
+                        dessertPrice * requestedQuantity,
+                        requestedQuantity
+                )
+        );
+        CreateRequest request = new CreateRequest(
+                mockStore.getId(),
+                PickupType.STORE_PICKUP,
+                orderItems.get(0).totalPrice(),
+                OrderStatus.PLACED,
+                LocalDateTime.now().plusMinutes(10),
+                orderItems
+        );
 
         given(storeRepository.findById(mockStore.getId())).willReturn(Optional.of(mockStore));
-        given(beverageItemRepository.findById(mockBeverage.getId())).willReturn(Optional.of(mockBeverage));
         given(memberRepository.findById(mockMember.getId())).willReturn(Optional.of(mockMember));
-        given(orderDailyCounterRepository.findById(any())).willReturn(Optional.of(new OrderDailyCounter(LocalDate.now(), 5)));
+        given(dessertItemRepository.findById(mockDessert.getId())).willReturn(Optional.of(mockDessert));
+        given(orderDailyCounterRepository.findById(any(LocalDate.class))).willReturn(Optional.of(new OrderDailyCounter(LocalDate.now(), 5))); // Mocking 값은 원하는 대로 유지 (예시에서는 5)
+
+        given(orderDailyCounterRepository.save(any(OrderDailyCounter.class))).willAnswer(invocation -> {
+                    OrderDailyCounter counter = invocation.getArgument(0);
+                    return counter;
+        });
+        given(orderRepository.save(any(Order.class))).willAnswer(invocation -> {
+            Order order = invocation.getArgument(0);
+            if (order.getId() == null) {
+                order = Order.builder()
+                        .id(2L)
+                        .orderNumber(order.getOrderNumber())
+                        .store(order.getStore())
+                        .member(order.getMember())
+                        .orderExpectedPickupTime(order.getOrderExpectedPickupTime())
+                        .orderStatus(order.getOrderStatus())
+                        .orderItems(order.getOrderItems())
+                        .orderTotalPrice(order.getOrderTotalPrice())
+                        .pickupType(order.getPickupType())
+                        .build();
+            }
+            for (OrderItem item : order.getOrderItems()) {
+                if (item.getOrder() == null) {
+                    item.setOrder(order);
+                }
+            }
+            return order;
+        });
 
         // When
         CreateResponse response = orderService.createOrder(request, mockMember.getId());
@@ -82,61 +207,74 @@ class OrderCreateTest {
         // Then
         assertThat(response.httpStatus()).isEqualTo(200);
         assertThat(response.message()).contains("성공");
+        assertThat(response.orderId()).isNotNull();
+        assertThat(response.orderId()).isEqualTo(2L);
+
+        verify(dessertItemRepository, times(1)).findById(mockDessert.getId());
+        verify(orderRepository, times(1)).save(any(Order.class));
     }
 
     @Test
     @DisplayName("존재하지 않는 매장 ID로 주문 생성 시 예외 발생")
     void createOrder_InvalidStoreId_ThrowsException() {
         // Given
+        int requestedQuantity = 1;
         List<ItemOptionRequest> options = List.of(
                 new ItemOptionRequest(1L, "WHIPPED_CREAM", false, 1, 500, 1)
         );
 
-        List<OrderItemRequest> orderItems = List.of(new OrderItemRequest(mockBeverage.getId(), ItemType.DRINK, BeverageSizeOption.TALL, BeverageTemperatureOption.HOT, options, 4100, 5000 ));
+        List<OrderItemRequest> orderItems = List.of(new OrderItemRequest(
+                mockBeverage.getId(),
+                ItemType.DRINK,
+                BeverageSizeOption.TALL,
+                BeverageTemperatureOption.HOT,
+                options,
+                4100,
+                5000,
+                requestedQuantity
+        ));
         CreateRequest request = new CreateRequest(999L, PickupType.STORE_PICKUP, 5000, OrderStatus.PLACED, LocalDateTime.now().plusMinutes(10), orderItems );
 
+        given(storeRepository.findById(999L)).willReturn(Optional.empty());
 
         // When & Then
-        assertThat(request.storeId().equals(mockStore.getId())).isFalse();
+        assertThatThrownBy(() -> orderService.createOrder(request, mockMember.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 매장입니다.");
+
+        verify(storeRepository, times(1)).findById(999L);
+        verify(orderRepository, never()).save(any(Order.class));
     }
 
     @Test
     @DisplayName("존재하지 않는 회원 ID로 주문 생성 시 예외 발생")
     void createOrder_InvalidMemberId_ThrowsException() {
         // Given
+        int requestedQuantity = 1;
         given(storeRepository.findById(mockStore.getId())).willReturn(Optional.of(mockStore));
         given(memberRepository.findById(999L)).willReturn(Optional.empty());
         List<ItemOptionRequest> options = List.of(
                 new ItemOptionRequest(1L, "WHIPPED_CREAM", false, 1, 500, 1)
         );
 
-        List<OrderItemRequest> orderItems = List.of(new OrderItemRequest(mockBeverage.getId(), ItemType.DRINK, BeverageSizeOption.TALL, BeverageTemperatureOption.HOT, options, 4100, 5000 ));
+        List<OrderItemRequest> orderItems = List.of(new OrderItemRequest(
+                mockBeverage.getId(),
+                ItemType.DRINK,
+                BeverageSizeOption.TALL,
+                BeverageTemperatureOption.HOT,
+                options,
+                4100,
+                5000,
+                requestedQuantity
+        ));
         CreateRequest request = new CreateRequest(mockStore.getId(), PickupType.STORE_PICKUP, 5000, OrderStatus.PLACED, LocalDateTime.now().plusMinutes(10), orderItems );
 
         // When & Then
         assertThatThrownBy(() -> orderService.createOrder(request, 999L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("존재하지 않는 사용자입니다.");
-    }
 
-    @Test
-    @DisplayName("존재하지 않는 음료 ID로 주문 생성 시 예외 발생")
-    void createOrder_InvalidBeverageId_ThrowsException() {
-        // Given
-        List<ItemOptionRequest> options = List.of(
-                new ItemOptionRequest(1L, "WHIPPED_CREAM", false, 1, 500, 1)
-        );
-
-        List<OrderItemRequest> orderItems = List.of(new OrderItemRequest(mockBeverage.getId(), ItemType.DRINK, BeverageSizeOption.TALL, BeverageTemperatureOption.HOT, options, 4100, 5000 ));
-        CreateRequest request = new CreateRequest(mockStore.getId(), PickupType.STORE_PICKUP, 5000, OrderStatus.PLACED, LocalDateTime.now().plusMinutes(10), orderItems );
-
-        given(storeRepository.findById(mockStore.getId())).willReturn(Optional.of(mockStore));
-        given(memberRepository.findById(mockMember.getId())).willReturn(Optional.of(mockMember));
-        given(beverageItemRepository.findById(orderItems.getFirst().itemId())).willReturn(Optional.empty());
-
-        // When & Then
-        assertThatThrownBy(() -> orderService.createOrder(request, mockMember.getId()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("존재하지 않는 음료입니다.");
+        verify(memberRepository, times(1)).findById(999L);
+        verify(orderRepository, never()).save(any(Order.class));
     }
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- *사용자가 앱에서 주문한 내역을 백엔드에서 받아 데이터베이스에 저장하는 #11 주문 내용 저장 기능을 구현했습니다.

# 🛠️ What’s been done?
- OrderController 수정
  - createOrder 메서드 내에서 OrderService.createOrder의 반환 값인 CreateResponse를 받아, 이를 SuccessResponse DTO의 result 필드에 담아 클라이언트에게 반환하도록 수정했습니다.

- 엔티티/DTO 수정
  - Order 엔티티의 orderItems 컬렉션에 cascade = CascadeType.ALL 속성을 추가하여 Order 저장 시 OrderItem들이 자동으로 함께 저장되도록 했습니다.
  - OrderItemRequest DTO에 quantity 필드를 추가했습니다.

# 🧪 Testing Details

- 테스트 코드 및 결과: 
OrderCreateTest.java (단위 테스트)를 작성/수정하여 OrderService의 createOrder 메서드 로직을 검증했습니다.
주요 테스트 케이스:
createOrder_Success(): 정상적인 음료 주문 생성 성공 검증 (ID: 1L)
createOrder_DessertSuccess(): 정상적인 디저트 주문 생성 성공 검증 (ID: 2L)
createOrder_InvalidStoreId_ThrowsException(): 존재하지 않는 매장 ID로 주문 시 IllegalArgumentException 발생 검증.
createOrder_InvalidMemberId_ThrowsException(): 존재하지 않는 회원 ID로 주문 시 IllegalArgumentException 발생 검증.
createOrder_InvalidBeverageId_ThrowsException(): 존재하지 않는 음료 ID로 주문 시 IllegalArgumentException 발생 검증.
createOrder_InvalidDessertId_ThrowsException(): 존재하지 않는 디저트 ID로 주문 시 IllegalArgumentException 발생 검증.
createOrder_DefaultValues(): request에 픽업 시간 및 주문 상태가 null일 때 기본값(LocalDateTime.now().plusMinutes(10), OrderStatus.PLACED)이 올바르게 적용되는지 검증.
테스트 성공 여부: 위에 명시된 모든 단위 테스트 케이스 성공 확인.

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

- close #11 
