### PR TITLE
[refactor] 과거 주문 내용 목록 조회 기능 수정

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/response/OrderListResponse.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/response/OrderListResponse.java
@@ -1,11 +1,9 @@
 package git_kkalnane.backend.starbucks.order.dto.response;
 
-import lombok.Builder;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
-@Builder
 public record OrderListResponse(
     List<OrderSummaryResponse> orders,
     int currentPage,
@@ -21,14 +19,14 @@ public record OrderListResponse(
      * @return OrderListResponse DTO 객체
      */
     public static OrderListResponse from(Page<OrderSummaryResponse> orderPage) {
-        return OrderListResponse.builder()
-                .orders(orderPage.getContent())
-                .currentPage(orderPage.getNumber())
-                .totalPages(orderPage.getTotalPages())
-                .totalElements(orderPage.getTotalElements())
-                .size(orderPage.getSize())
-                .isFirst(orderPage.isFirst())
-                .isLast(orderPage.isLast())
-                .build();
+        return new OrderListResponse(
+                orderPage.getContent(),
+                orderPage.getNumber(),
+                orderPage.getTotalPages(),
+                orderPage.getTotalElements(),
+                orderPage.getSize(),
+                orderPage.isFirst(),
+                orderPage.isLast()
+        );
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/response/OrderSummaryResponse.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/response/OrderSummaryResponse.java
@@ -2,11 +2,9 @@ package git_kkalnane.backend.starbucks.order.dto.response;
 
 import git_kkalnane.backend.starbucks.order.domain.Order;
 import git_kkalnane.backend.starbucks.order.domain.OrderStatus;
-import lombok.Builder;
 
 import java.time.LocalDateTime;
 
-@Builder
 public record OrderSummaryResponse(
         Long orderId,
         String orderNumber,
@@ -21,13 +19,14 @@ public record OrderSummaryResponse(
      * @return OrderSummaryResponse DTO 객체
      */
     public static OrderSummaryResponse from(Order order) {
-        return OrderSummaryResponse.builder()
-                .orderId(order.getId())
-                .orderNumber(order.getOrderNumber())
-                .storeName(order.getStore().getName())
-                .orderTotalPrice(order.getOrderTotalPrice())
-                .orderStatus(order.getOrderStatus())
-                .orderCreatedAt(order.getCreatedAt())
-                .build();
+        return new OrderSummaryResponse(
+                order.getId(),
+                order.getOrderNumber(),
+                order.getStore().getName(),
+                order.getOrderTotalPrice(),
+                order.getOrderStatus(),
+                order.getCreatedAt()
+        );
+
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/repository/OrderRepository.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/repository/OrderRepository.java
@@ -1,13 +1,16 @@
 package git_kkalnane.backend.starbucks.order.repository;
 
 import git_kkalnane.backend.starbucks.order.domain.Order;
+import git_kkalnane.backend.starbucks.order.domain.OrderStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    Page<Order> findByMemberId(Long memberId, Pageable pageable);
+    Page<Order> findByMemberIdAndOrderStatusIn(Long memberId, Collection<OrderStatus> statuses, Pageable pageable);
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/service/OrderService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/service/OrderService.java
@@ -13,6 +13,7 @@ import git_kkalnane.backend.starbucks.order.domain.Order;
 import git_kkalnane.backend.starbucks.order.domain.OrderDailyCounter;
 import git_kkalnane.backend.starbucks.order.domain.OrderItem;
 
+import git_kkalnane.backend.starbucks.order.domain.OrderStatus;
 import git_kkalnane.backend.starbucks.order.dto.request.CreateRequest;
 import git_kkalnane.backend.starbucks.order.dto.request.OrderItemRequest;
 import git_kkalnane.backend.starbucks.order.dto.response.CreateResponse;
@@ -178,7 +179,9 @@ public class OrderService {
     public OrderListResponse getOrderHistory(Long memberId, Pageable pageable){
     Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new OrderException(OrderErrorCode.MEMBER_NOT_FOUND));
-        Page<Order> orderPage = orderRepository.findByMemberId(memberId, pageable);
+
+        List<OrderStatus> pastOrderStatuses = List.of(OrderStatus.COMPLETED);
+        Page<Order> orderPage = orderRepository.findByMemberIdAndOrderStatusIn(memberId, pastOrderStatuses, pageable);
         Page<OrderSummaryResponse> summaryPage = orderPage.map(OrderSummaryResponse::from);
 
         return OrderListResponse.from(summaryPage);

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/order/OrderServiceTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/order/OrderServiceTest.java
@@ -37,6 +37,7 @@ import org.springframework.data.domain.Pageable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -372,36 +373,28 @@ class OrderServiceTest {
     void getOrderHistory_Success() {
         // Given
         Long memberId = 1L;
-        Pageable pageable = PageRequest.of(0, 5); // 0번째 페이지, 5개씩
+        Pageable pageable = PageRequest.of(0, 5);
 
-        Order order1 = Order.builder().id(10L).orderNumber("A-1").store(mockStore).build();
-        Order order2 = Order.builder().id(11L).orderNumber("A-2").store(mockStore).build();
+        Order order1 = Order.builder().id(10L).orderNumber("A-1").store(mockStore).orderStatus(OrderStatus.COMPLETED).build();
+        Order order2 = Order.builder().id(11L).orderNumber("A-2").store(mockStore).orderStatus(OrderStatus.COMPLETED).build();
         List<Order> orderList = List.of(order1, order2);
-
         Page<Order> mockOrderPage = new PageImpl<>(orderList, pageable, orderList.size());
 
-        // Mocking 설정
         given(memberRepository.findById(memberId)).willReturn(Optional.of(mockMember));
-        given(orderRepository.findByMemberId(memberId, pageable)).willReturn(mockOrderPage);
+        given(orderRepository.findByMemberIdAndOrderStatusIn(eq(memberId), any(Collection.class), eq(pageable)))
+                .willReturn(mockOrderPage);
 
         // When
         OrderListResponse response = orderService.getOrderHistory(memberId, pageable);
 
         // Then
-        // 1. 응답의 페이지 정보 검증
         assertThat(response).isNotNull();
         assertThat(response.currentPage()).isEqualTo(0);
-        assertThat(response.totalPages()).isEqualTo(1);
-        assertThat(response.totalElements()).isEqualTo(2);
-
-        // 2. 응답의 주문 목록 내용 검증
         assertThat(response.orders()).hasSize(2);
         assertThat(response.orders().get(0).orderNumber()).isEqualTo("A-1");
-        assertThat(response.orders().get(0).storeName()).isEqualTo("스타벅스 강남점");
 
-        // 3. Repository 메서드 호출 검증
         verify(memberRepository, times(1)).findById(memberId);
-        verify(orderRepository, times(1)).findByMemberId(memberId, pageable);
+        verify(orderRepository, times(1)).findByMemberIdAndOrderStatusIn(eq(memberId), any(Collection.class), eq(pageable));
     }
 
     @Test
@@ -418,9 +411,7 @@ class OrderServiceTest {
                 .isInstanceOf(OrderException.class)
                 .hasMessage(OrderErrorCode.MEMBER_NOT_FOUND.getMessage());
 
-        // 1. 회원 조회는 시도했는지 검증
         verify(memberRepository, times(1)).findById(nonExistentMemberId);
-        // 2. 회원을 찾지 못했으므로 주문 내역 조회는 시도조차 하지 않았는지 검증
-        verify(orderRepository, never()).findByMemberId(anyLong(), any(Pageable.class));
+        verify(orderRepository, never()).findByMemberIdAndOrderStatusIn(anyLong(), any(Collection.class), any(Pageable.class));
     }
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 과거 주문 내역 조회(#12) PR에 대한 피드백을 반영하여 로직을 수정하고 코드를 개선합니다.

# 🛠️ What’s been done?

- 과거 주문 필터링 로직 수정
  - OrderService의 getOrderHistory가 OrderStatus가 COMPLETED인 주문만 조회하도록 수정했습니다.
  - OrderRepository에 findByMemberIdAndOrderStatusIn 쿼리 메서드를 추가하고, 서비스가 이를 호출하도록 변경했습니다.

- DTO 생성 스타일 통일

  - OrderSummaryResponse, OrderListResponse 등 관련 DTO에서 @Builder 어노테이션을 제거했습니다.


# 🧪 Testing Details

- 테스트 코드 및 결과:

  - 변경된 OrderService의 로직에 맞춰 OrderServiceTest의 단위 테스트 코드를 수정했습니다.
  - Repository의 Mocking 대상을 새로운 메서드(findByMemberIdAndOrderStatusIn)로 변경하여, 수정된 로직이 올바르게 동작함을 검증했습니다.

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

- closes #140 