### PR TITLE
[feat] 현재 준비중인 주문 내용 조회 기능 구현

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/item/domain/beverage/BeverageItem.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/item/domain/beverage/BeverageItem.java
@@ -40,6 +40,9 @@ public class BeverageItem extends BaseTimeEntity {
     @Column(name = "price", nullable = false)
     private int price;
 
+    @Column(name = "is_coffee", nullable = false)
+    private boolean isCoffee = false;
+
     @Column(name = "hot_image_url", length = 254)
     private String hotImageUrl;
 

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/common/exception/OrderErrorCode.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/common/exception/OrderErrorCode.java
@@ -10,8 +10,8 @@ public enum OrderErrorCode implements ErrorCode {
     ORDER_ERROR_CODE(HttpStatus.BAD_REQUEST, "주문생성이 실패했습니다."),
     INVALID_ORDER_ITEM_REFERENCE(HttpStatus.BAD_REQUEST, "주문 상품이 유효한 메뉴를 참조하지 않습니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 주문을 찾을 수 없습니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다");
-
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 매장을 찾을 수 없습니다.");
     private final HttpStatus status;
     private final String message;
 

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/common/success/OrderSuccessCode.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/common/success/OrderSuccessCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum OrderSuccessCode implements SuccessCode {
     ORDER_SUCCESS_CREATED(HttpStatus.CREATED, "주문이 성공적으로 생성되었습니다."),
-    ORDER_DETAIL_VIEWED(HttpStatus.OK, "주문 상세 정보 조회가 성공했습니다.");
+    ORDER_DETAIL_VIEWED(HttpStatus.OK, "주문 상세 정보 조회가 성공했습니다."),
+    ORDER_CURRENT_VIEWED(HttpStatus.OK, "현재 진행중인 주문 목록 조회가 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/controller/OrderController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package git_kkalnane.backend.starbucks.order.controller;
 
 import git_kkalnane.backend.starbucks._global.success.SuccessResponse;
 import git_kkalnane.backend.starbucks.order.common.success.OrderSuccessCode;
+import git_kkalnane.backend.starbucks.order.dto.response.CurrentOrderResponse;
 import git_kkalnane.backend.starbucks.order.dto.response.OrderDetailResponse;
 import git_kkalnane.backend.starbucks.order.dto.response.OrderListResponse;
 import git_kkalnane.backend.starbucks.order.dto.request.CreateOrderDTO;
@@ -17,6 +18,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 주문 관련 API 컨트롤러
@@ -79,4 +82,16 @@ public class OrderController {
                 .body(SuccessResponse.of(OrderSuccessCode.ORDER_DETAIL_VIEWED, orderList));
     }
 
+    @Operation(summary = "현재 주문 목록 조회", description = "현재 로그인한 사용자의 진행중인(접수, 준비중, 픽업 가능) 모든 주문 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/users/{memberId}/current")
+    public ResponseEntity<SuccessResponse> getCurrentOrders(@PathVariable Long memberId) {
+
+        List<CurrentOrderResponse> result = orderService.getCurrentOrders(memberId);
+
+        return ResponseEntity
+                .ok(SuccessResponse.of(OrderSuccessCode.ORDER_CURRENT_VIEWED, result));
+    }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/controller/주문API.http
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/controller/주문API.http
@@ -60,33 +60,39 @@ GET {{baseUrl}}/orders/99999
 Accept: application/json
 
 ### ========================================
-### #12 과거 주문 내역 목록 조회 (통합 테스트)
+### 과거 주문 내역 목록 조회 (통합 테스트)
 ### ========================================
 
 ### 1. 기본 조회 (성공 케이스)
 GET {{baseUrl}}/orders/history?memberId={{memberIdWithOrders}}&page=0&size=5
 Accept: application/json
 
-### ---
-
 ### 2. 페이징 기능 테스트
 GET {{baseUrl}}/orders/history?memberId={{memberIdWithOrders}}&page=1&size=3
 Accept: application/json
-
-### ---
 
 ### 3. 정렬 기능 테스트
 GET {{baseUrl}}/orders/history?memberId={{memberIdWithOrders}}&sort=id,asc
 Accept: application/json
 
-### ---
-
 ### 4. 주문 내역이 없는 회원 조회 
 GET {{baseUrl}}/orders/history?memberId={{memberIdWithoutOrders}}
 Accept: application/json
 
-### ---
-
 ### 5. 존재하지 않는 회원 조회
 GET {{baseUrl}}/orders/history?memberId={{nonExistentMemberId}}
+Accept: application/json
+
+### ========================================
+### 준비중인 주문 목록 조회
+### ========================================
+
+### 1. 현재 진행중인 주문 목록 조회 (성공 케이스)
+# 기능: 1번 회원의 현재 주문들을 조회합니다.
+GET {{baseUrl}}/orders/users/{{memberIdWithOrders}}/current
+Accept: application/json
+
+### 2. 현재 진행중인 주문이 없는 사용자 조회 (정상 엣지 케이스)
+# 기능: 2번 회원의 주문이 없는 경우, 빈 목록이 반환되는지 확인합니다.
+GET {{baseUrl}}/orders/users/{{memberIdWithoutOrders}}/current
 Accept: application/json

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/Order.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/Order.java
@@ -51,6 +51,7 @@ public class Order extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Builder.Default
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
 

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/OrderItem.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/OrderItem.java
@@ -2,6 +2,7 @@ package git_kkalnane.backend.starbucks.order.domain;
 
 import git_kkalnane.backend.starbucks._global.entity.BaseTimeEntity;
 import git_kkalnane.backend.starbucks.item.domain.beverage.BeverageItem;
+import git_kkalnane.backend.starbucks.item.domain.beverage.enums.BeverageTemperatureOption;
 import git_kkalnane.backend.starbucks.item.domain.dessert.DessertItem;
 import jakarta.persistence.*;
 import lombok.*;
@@ -39,6 +40,10 @@ public class OrderItem extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "dessert_item_id")
     private DessertItem dessertItem;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "temperature_option_at_order")
+    private BeverageTemperatureOption temperatureOption;
 
     public void setOrder(Order order) {
         this.order = order;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/response/CurrentOrderResponse.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/response/CurrentOrderResponse.java
@@ -1,0 +1,107 @@
+package git_kkalnane.backend.starbucks.order.dto.response;
+
+import git_kkalnane.backend.starbucks.item.domain.ItemType;
+import git_kkalnane.backend.starbucks.item.domain.beverage.BeverageItem;
+import git_kkalnane.backend.starbucks.item.domain.beverage.enums.BeverageSizeOption;
+import git_kkalnane.backend.starbucks.item.domain.beverage.enums.BeverageTemperatureOption;
+import git_kkalnane.backend.starbucks.order.domain.Order;
+import git_kkalnane.backend.starbucks.order.domain.OrderItem;
+import git_kkalnane.backend.starbucks.order.domain.OrderStatus;
+import git_kkalnane.backend.starbucks.order.domain.PickupType;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 현재 진행중인 주문 목록 조회를 위한 상세 응답 DTO
+ */
+public record CurrentOrderResponse (
+        Long orderId,
+        String orderIdUI,
+        Long storeId,
+        String storeName,
+        String storeAddress,
+        OrderStatus orderStatus,
+        PickupType pickupType,
+        List<OrderItemDetail> orderItems
+) {
+
+    /**
+     * Order 엔티티를 CurrentOrderResponse DTO로 변환하는 정적 팩토리 메서드
+     * @param order 변환할 Order 엔티티
+     * @return CurrentOrderResponse DTO
+     */
+    public static CurrentOrderResponse from(Order order) {
+        List<OrderItemDetail> itemDetails = order.getOrderItems().stream()
+                .map(OrderItemDetail::from)
+                .collect(Collectors.toList());
+
+        return new CurrentOrderResponse(
+                order.getId(),
+                order.getOrderNumber(),
+                order.getStore().getId(),
+                order.getStore().getName(),
+                order.getStore().getAddress(),
+                order.getOrderStatus(),
+                order.getPickupType(),
+                itemDetails
+        );
+    }
+
+    /**
+     * 주문에 포함된 개별 상품의 상세 정보를 담는 내부 DTO
+     */
+    public record OrderItemDetail(
+            String name_ko,
+            String name_en,
+            ItemType itemType,
+            boolean isCoffee,
+            Set<BeverageTemperatureOption> temperatureOption,
+            Set<BeverageSizeOption> sizeOption,
+            String img_url,
+            int quantity,
+            int totalPrice,
+            int itemPrice
+
+    ) {
+        public static OrderItemDetail from(OrderItem orderItem) {
+            if (orderItem.getBeverageItem() != null) {
+                BeverageItem beverage = orderItem.getBeverageItem();
+                String imageUrl;
+
+                if (orderItem.getTemperatureOption() == BeverageTemperatureOption.HOT) {
+                    imageUrl = beverage.getHotImageUrl();
+                } else {
+                    imageUrl = beverage.getIceImageUrl();
+                }
+
+                return new OrderItemDetail(
+                        orderItem.getItemName(),
+                        beverage.getBeverageItemNameEn(),
+                        beverage.isCoffee() ? ItemType.COFFEE : ItemType.BEVERAGE,
+                        beverage.isCoffee(),
+                        beverage.getSupportedTemperatures(),
+                        beverage.getSupportedSizes(),
+                        imageUrl,
+                        orderItem.getOrderItemQuantity(),
+                        orderItem.getUnitPrice() * orderItem.getOrderItemQuantity(),
+                        orderItem.getUnitPrice()
+                );
+            } else {
+                return new OrderItemDetail(
+                        orderItem.getItemName(),
+                        orderItem.getDessertItem().getDessertItemNameEn(),
+                        ItemType.DESSERT,
+                        false,
+                        null,
+                        null,
+                        orderItem.getDessertItem().getImageUrl(),
+                        orderItem.getOrderItemQuantity(),
+                        orderItem.getUnitPrice() * orderItem.getOrderItemQuantity(),
+                        orderItem.getUnitPrice()
+                );
+            }
+        }
+    }
+}

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/repository/OrderRepository.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/repository/OrderRepository.java
@@ -8,9 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
+import java.util.List;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Page<Order> findByMemberIdAndOrderStatusIn(Long memberId, Collection<OrderStatus> statuses, Pageable pageable);
+    List<Order> findByMemberIdAndOrderStatusInOrderByCreatedAtAsc(Long memberId, List<OrderStatus> statuses);
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/service/OrderService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/service/OrderService.java
@@ -12,13 +12,9 @@ import git_kkalnane.backend.starbucks.order.common.exception.OrderException;
 import git_kkalnane.backend.starbucks.order.domain.Order;
 import git_kkalnane.backend.starbucks.order.domain.OrderDailyCounter;
 import git_kkalnane.backend.starbucks.order.domain.OrderItem;
-<<<<<<< HEAD
-=======
-
 import git_kkalnane.backend.starbucks.order.domain.OrderStatus;
-import git_kkalnane.backend.starbucks.order.dto.request.CreateRequest;
->>>>>>> origin/feat/#12-order-list
 import git_kkalnane.backend.starbucks.order.dto.request.OrderItemRequest;
+import git_kkalnane.backend.starbucks.order.dto.response.CurrentOrderResponse;
 import git_kkalnane.backend.starbucks.order.dto.response.OrderDetailResponse;
 import git_kkalnane.backend.starbucks.order.dto.response.OrderListResponse;
 import git_kkalnane.backend.starbucks.order.dto.response.OrderSummaryResponse;
@@ -31,9 +27,7 @@ import git_kkalnane.backend.starbucks.store.domain.Store;
 import git_kkalnane.backend.starbucks.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -95,10 +89,9 @@ public class OrderService {
             order.addOrderItem(item);
         }
 
-        orderRepository.save(order);
-        orderItemRepository.saveAll(orderItems);
+        Order savedOrder = orderRepository.save(order);
 
-        return order;
+        return savedOrder;
 
     }
 
@@ -193,6 +186,28 @@ public class OrderService {
         Page<OrderSummaryResponse> summaryPage = orderPage.map(OrderSummaryResponse::from);
 
         return OrderListResponse.from(summaryPage);
-
     }
+    /**
+     * 특정 회원의 현재 진행중인 모든 주문 목록(주문 접수, 준비중, 픽업 가능)을 조회합니다.
+     *
+     * @param memberId 조회할 회원의 ID
+     * @return 현재 진행중인 주문의 상세 정보 DTO 리스트
+     */
+    public List<CurrentOrderResponse> getCurrentOrders(Long memberId) {
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.MEMBER_NOT_FOUND));
+
+        List<OrderStatus> currentStatuses = List.of(
+                OrderStatus.PLACED,
+                OrderStatus.PREPARING,
+                OrderStatus.READY_FOR_PICKUP
+        );
+
+        List<Order> currentOrders = orderRepository.findByMemberIdAndOrderStatusInOrderByCreatedAtAsc(memberId, currentStatuses);
+
+        return currentOrders.stream()
+                .map(CurrentOrderResponse::from)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/order/OrderServiceTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/order/OrderServiceTest.java
@@ -15,9 +15,11 @@ import git_kkalnane.backend.starbucks.order.domain.*;
 import git_kkalnane.backend.starbucks.order.dto.request.CreateOrderDTO;
 import git_kkalnane.backend.starbucks.order.dto.request.ItemOptionRequest;
 import git_kkalnane.backend.starbucks.order.dto.request.OrderItemRequest;
+import git_kkalnane.backend.starbucks.order.dto.response.CurrentOrderResponse;
 import git_kkalnane.backend.starbucks.order.dto.response.OrderDetailResponse;
 import git_kkalnane.backend.starbucks.order.dto.response.OrderListResponse;
 import git_kkalnane.backend.starbucks.order.repository.OrderDailyCounterRepository;
+import git_kkalnane.backend.starbucks.order.repository.OrderItemRepository;
 import git_kkalnane.backend.starbucks.order.repository.OrderRepository;
 import git_kkalnane.backend.starbucks.store.domain.Store;
 import git_kkalnane.backend.starbucks.store.repository.StoreRepository;
@@ -35,10 +37,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -52,6 +51,8 @@ class OrderServiceTest {
     @Mock private BeverageItemRepository beverageItemRepository;
     @Mock private DessertItemRepository dessertItemRepository;
     @Mock private OrderRepository orderRepository;
+    @Mock private OrderItemRepository orderItemRepository;
+
 
     @InjectMocks private OrderService orderService;
 
@@ -62,9 +63,9 @@ class OrderServiceTest {
 
     @BeforeEach
     void 정보_세팅() {
-        mockStore = Store.builder().id(1L).name("스타벅스 강남점").build();
-        mockMember = Member.builder().id(1L).build();
-        mockBeverage = BeverageItem.builder().id(101L).beverageItemNameKo("아이스 아메리카노").price(4500).build();
+        mockMember = Member.builder().id(1L).name("장원영").build();
+        mockStore = Store.builder().id(1L).name("스타벅스 강남점").address("서울시 강남구 강남대로 123").build();
+        mockBeverage = BeverageItem.builder().id(101L).beverageItemNameKo("아이스 아메리카노").price(4500).isCoffee(true).build();
         mockDessert = DessertItem.builder().id(201L).dessertItemNameKo("치즈케이크").price(5500).build();
     }
 
@@ -102,9 +103,8 @@ class OrderServiceTest {
         given(memberRepository.findById(mockMember.getId())).willReturn(Optional.of(mockMember));
         given(beverageItemRepository.findById(mockBeverage.getId())).willReturn(Optional.of(mockBeverage));
         OrderDailyCounterId counterId = new OrderDailyCounterId(LocalDate.now(), mockStore.getId());
-
         given(orderDailyCounterRepository.findById(any(OrderDailyCounterId.class)))
-                .willReturn(Optional.of(new OrderDailyCounter(counterId, 0))); // 처음에는 0, increment 후 1
+                .willReturn(Optional.of(new OrderDailyCounter(counterId, 0)));
         given(orderDailyCounterRepository.save(any(OrderDailyCounter.class)))
                 .willAnswer(invocation -> {
                     OrderDailyCounter counter = invocation.getArgument(0);
@@ -145,7 +145,7 @@ class OrderServiceTest {
         verify(storeRepository, times(1)).findById(mockStore.getId());
         verify(memberRepository, times(1)).findById(mockMember.getId());
         verify(beverageItemRepository, times(1)).findById(mockBeverage.getId());
-        verify(orderDailyCounterRepository, times(1)).findById(any(LocalDate.class));
+        verify(orderDailyCounterRepository, times(1)).findById(any(OrderDailyCounterId.class));
         verify(orderDailyCounterRepository, times(1)).save(any(OrderDailyCounter.class));
         verify(orderRepository, times(1)).save(any(Order.class));
     }
@@ -418,4 +418,49 @@ class OrderServiceTest {
         verify(memberRepository, times(1)).findById(nonExistentMemberId);
         verify(orderRepository, never()).findByMemberIdAndOrderStatusIn(anyLong(), any(Collection.class), any(Pageable.class));
     }
+
+    @Test
+    @DisplayName("나의 현재 주문 목록 조회 성공")
+    void getCurrentOrders_Success() {
+        // Given
+        Long memberId = 1L;
+
+        Order order1 = Order.builder().id(20L).orderNumber("B-1").member(mockMember).store(mockStore).orderStatus(OrderStatus.PREPARING).build();
+        Order order2 = Order.builder().id(21L).orderNumber("B-2").member(mockMember).store(mockStore).orderStatus(OrderStatus.READY_FOR_PICKUP).build();
+        List<Order> mockOrderList = List.of(order1, order2);
+
+        given(orderRepository.findByMemberIdAndOrderStatusInOrderByCreatedAtAsc(eq(memberId), anyList()))
+                .willReturn(mockOrderList);
+
+        // When
+        List<CurrentOrderResponse> result = orderService.getCurrentOrders(memberId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).orderIdUI()).isEqualTo("B-1");
+        assertThat(result.get(0).storeName()).isEqualTo("스타벅스 강남점");
+
+        verify(orderRepository, times(1)).findByMemberIdAndOrderStatusInOrderByCreatedAtAsc(eq(memberId), anyList());
+    }
+
+    @Test
+    @DisplayName("나의 현재 주문 목록이 없을 경우 빈 리스트 반환")
+    void getCurrentOrders_ReturnsEmptyList_WhenNoOrders() {
+        // Given
+        Long memberId = 2L;
+
+        given(orderRepository.findByMemberIdAndOrderStatusInOrderByCreatedAtAsc(eq(memberId), anyList()))
+                .willReturn(Collections.emptyList());
+
+        // When
+        List<CurrentOrderResponse> result = orderService.getCurrentOrders(memberId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+
+        verify(orderRepository, times(1)).findByMemberIdAndOrderStatusInOrderByCreatedAtAsc(eq(memberId), anyList());
+    }
+
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- **작업 내용 요약:** 이 PR에서 해결하거나 추가한 내용을 간략히 설명해 주세요.

# 🛠️ What’s been done?

- API 엔드포인트 추가
  - GET /orders/users/{memberId}/current 엔드포인트를 추가하여 특정 사용자의 현재 진행중인 모든 주문을 조회합니다.

- 서비스 로직 구현
  - getCurrentOrders 메서드를 구현하여, 주문 상태가 PLACED, PREPARING, READY_FOR_PICKUP인 주문들만 필터링하도록 로직을 작성했습니다.
  - OrderRepository에 findByMemberIdAndOrderStatusInOrderByCreatedAtAsc 쿼리 메서드를 추가하여, 조회된 주문들이 생성 시간 순으로 정렬되도록 했습니다.

- 상세 응답 DTO 정의 (CurrentOrderResponse)
  - 조회 결과를 담을 새로운 응답 DTO인 CurrentOrderResponse와 그 내부에 중첩된 OrderItemDetail 레코드(Record)를 정의했습니다.
  - OrderItemDetail은 주문 상품이 음료인지 디저트인지 구분하고, 음료의 경우 선택된 temperatureOption에 따라 hotImageUrl과 iceImageUrl 중 적절한 이미지 URL을 동적으로 결정하는 로직을 포함합니다.

- 성공 및 예외 처리
  - OrderSuccessCode에 ORDER_CURRENT_VIEWED를 추가하여 API 성공 응답을 했습니다.
  - 존재하지 않는 회원 ID로 조회 시 MEMBER_NOT_FOUND 예외가 발생하도록 처리했습니다.

# 🧪 Testing Details

- 단위 테스트 (OrderServiceTest)
  - getCurrentOrders_Success: 현재 주문이 있는 사용자의 목록이 정상적으로 조회되는지 확인합니다.
  - getCurrentOrders_ReturnsEmptyList_WhenNoOrders: 현재 주문이 없는 사용자의 경우 빈 리스트([])가 반환되는지 확인합니다.
  - 모든 단위 테스트 케이스가 성공적으로 통과하는 것을 확인했습니다.

- API 테스트
  - 추후 데이터 추가 시 진행하겠습니다. 

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

- closes #13 