### PR TITLE
[refactor] 매장 목록 조회 시 드라이브 쓰루 여부 표시

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/store/dto/response/StoreSummaryResponse.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/store/dto/response/StoreSummaryResponse.java
@@ -10,14 +10,13 @@ import lombok.RequiredArgsConstructor;
  * @author Seongjun In
  * @version 1.0
  */
-@Getter
-@RequiredArgsConstructor
-public class StoreSummaryResponse {
-    private final Long id;
-    private final String name;
-    private final String address;
-    private final String imageUrl;
-
+public record StoreSummaryResponse (
+    Long id,
+    String name,
+    String address,
+    String imageUrl,
+    boolean hasDriveThrough
+){
     /**
      * Store 엔티티를 StoreSummaryResponse DTO로 변환합니다.
      * @param store 원본 Store 엔티티
@@ -28,7 +27,8 @@ public class StoreSummaryResponse {
                 store.getId(),
                 store.getName(),
                 store.getAddress(),
-                store.getImageUrl()
+                store.getImageUrl(),
+                store.isHasDriveThrough()
         );
     }
 }

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/store/service/StoreServiceTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/store/service/StoreServiceTest.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat; // AssertJ 임포트 통일
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -57,6 +57,7 @@ class StoreServiceTest {
                 .id(2L)
                 .name("홍대입구역점")
                 .address("서울 마포구")
+                .hasDriveThrough(false)
                 .imageUrl("/images/stores/hongdae.jpg")
                 .build();
     }
@@ -77,17 +78,14 @@ class StoreServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.getId()).isEqualTo(storeId);
         assertThat(response.getName()).isEqualTo("강남역점");
-        assertThat(response.getCurrentCrowdLevel()).isEqualTo(CrowdLevel.MEDIUM);
     }
 
 
     @Test
-    @DisplayName("지점 목록 조회 시, Pageable을 사용하여 페이징된 결과를 올바르게 반환한다")
-    void getStoreList_Success() {
+    @DisplayName("지점 목록 조회 시, 드라이브스루 여부를 포함한 페이징된 결과를 올바르게 반환한다")
+    void getStoreList_IncludesDriveThru_Success() {
         // Given
-        int page = 0;
-        int size = 15;
-        Pageable pageable = PageRequest.of(page, size, Sort.by("name"));
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("name"));
 
         List<Store> storeList = Arrays.asList(mockStore1, mockStore2);
         Page<Store> storePage = new PageImpl<>(storeList, pageable, storeList.size());
@@ -101,10 +99,11 @@ class StoreServiceTest {
         verify(storeRepository, times(1)).findAll(any(Pageable.class));
         assertThat(result).isNotNull();
         assertThat(result.getStores()).hasSize(2);
-        assertThat(result.getCurrentPage()).isEqualTo(page);
+        assertThat(result.getCurrentPage()).isEqualTo(0);
         assertThat(result.getTotalCount()).isEqualTo(storeList.size());
-        assertThat(result.getStores().get(0).getName()).isEqualTo("강남역점");
-        assertThat(result.getStores().get(0).getAddress()).isEqualTo("서울 강남구");
+
+        assertThat(result.getStores().get(0).hasDriveThrough()).isTrue();
+        assertThat(result.getStores().get(1).hasDriveThrough()).isFalse();
     }
 
     @Test
@@ -114,12 +113,11 @@ class StoreServiceTest {
         Long nonExistentId = 999L;
         given(storeRepository.findById(nonExistentId)).willReturn(Optional.empty());
 
-        // When
+        // When & Then
         assertThrows(StoreException.class, () -> {
             storeService.getStoreDetails(nonExistentId);
         });
 
-        // Then
         verify(storeRepository).findById(nonExistentId);
     }
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 매장 목록 조회 시 드라이브 쓰루 여부를 추가하였습니다.

# 🛠️ What’s been done?

- response
  -  StoreSummaryResponse DTO를 record로 리팩토링
  - StoreSummaryResponse에 hasDriveThrough 필드 추가.

# 🧪 Testing Details

- 서비스단 테스트
  - StoreServiceTest : 지점 목록 조회 시, 드라이브스루 여부를 포함한 페이징된 결과를 올바르게 반환하는지 테스트 진행
  - 서비스단 테스트 성공적으로 진행

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

- closes #169 
