### PR TITLE
[test] 토큰 저장 테스트 코드 구현

### DIFF
--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/auth/service/AuthServiceTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/auth/service/AuthServiceTest.java
@@ -272,6 +272,158 @@ class AuthServiceTest {
     }
 
     @Nested
+    @DisplayName("토큰저장 테스트")
+    class SaveTokenTest {
+
+        @Nested
+        @DisplayName("AccessToken 저장 테스트")
+        class AccessTokenSaveTest {
+
+            @Test
+            @DisplayName("새로운 AccessToken을 저장할 수 있다")
+            void saveAccessToken_NewToken() {
+                // given
+                Long memberId = 1L;
+                TokenInfo tokenInfo = TokenInfo.builder().token("new-access-token")
+                        .expiration(new Date(System.currentTimeMillis() + 3600000)).build();
+
+                when(accessTokenRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+                when(accessTokenRepository.save(any(AccessToken.class)))
+                        .thenReturn(AccessToken.builder().memberId(memberId).token(tokenInfo.getToken())
+                                .expiration(tokenInfo.getExpiration()).build());
+
+                // when
+                authService.saveAccessTokenToRepository(memberId, tokenInfo);
+
+                // then
+                verify(accessTokenRepository, times(1)).findByMemberId(memberId);
+                verify(accessTokenRepository, times(1)).save(any(AccessToken.class));
+            }
+
+            @Test
+            @DisplayName("기존 AccessToken을 업데이트할 수 있다")
+            void saveAccessToken_UpdateExistingToken() {
+                // given
+                Long memberId = 1L;
+                TokenInfo newTokenInfo = TokenInfo.builder().token("updated-access-token")
+                        .expiration(new Date(System.currentTimeMillis() + 3600000)).build();
+
+                AccessToken existingToken =
+                        AccessToken.builder().memberId(memberId).token("old-access-token")
+                                .expiration(new Date(System.currentTimeMillis() - 1000)).build();
+
+                when(accessTokenRepository.findByMemberId(memberId)).thenReturn(Optional.of(existingToken));
+
+                // when
+                authService.saveAccessTokenToRepository(memberId, newTokenInfo);
+
+                // then
+                verify(accessTokenRepository, times(1)).findByMemberId(memberId);
+                verify(accessTokenRepository, times(0)).save(any(AccessToken.class));
+
+                // 기존 토큰이 업데이트되었는지 확인
+                assertThat(existingToken.getToken()).isEqualTo(newTokenInfo.getToken());
+                assertThat(existingToken.getExpiration()).isEqualTo(newTokenInfo.getExpiration());
+            }
+
+            @Test
+            @DisplayName("다른 memberId의 AccessToken을 저장할 수 있다")
+            void saveAccessToken_DifferentMemberId() {
+                // given
+                Long differentMemberId = 999L;
+                TokenInfo tokenInfo = TokenInfo.builder().token("different-access-token")
+                        .expiration(new Date(System.currentTimeMillis() + 3600000)).build();
+
+                when(accessTokenRepository.findByMemberId(differentMemberId)).thenReturn(Optional.empty());
+                when(accessTokenRepository.save(any(AccessToken.class)))
+                        .thenReturn(AccessToken.builder().memberId(differentMemberId)
+                                .token(tokenInfo.getToken()).expiration(tokenInfo.getExpiration()).build());
+
+                // when
+                authService.saveAccessTokenToRepository(differentMemberId, tokenInfo);
+
+                // then
+                verify(accessTokenRepository, times(1)).findByMemberId(differentMemberId);
+                verify(accessTokenRepository, times(1)).save(any(AccessToken.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("RefreshToken 저장 테스트")
+        class RefreshTokenSaveTest {
+
+            @Test
+            @DisplayName("새로운 RefreshToken을 저장할 수 있다")
+            void saveRefreshToken_NewToken() {
+                // given
+                Long memberId = 1L;
+                TokenInfo tokenInfo = TokenInfo.builder().token("new-refresh-token")
+                        .expiration(new Date(System.currentTimeMillis() + 86400000)).build();
+
+                when(refreshTokenRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+                when(refreshTokenRepository.save(any(RefreshToken.class)))
+                        .thenReturn(RefreshToken.builder().memberId(memberId).token(tokenInfo.getToken())
+                                .expiration(tokenInfo.getExpiration()).build());
+
+                // when
+                authService.saveRefreshTokenToRepository(memberId, tokenInfo);
+
+                // then
+                verify(refreshTokenRepository, times(1)).findByMemberId(memberId);
+                verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+            }
+
+            @Test
+            @DisplayName("기존 RefreshToken을 업데이트할 수 있다")
+            void saveRefreshToken_UpdateExistingToken() {
+                // given
+                Long memberId = 1L;
+                TokenInfo newTokenInfo = TokenInfo.builder().token("updated-refresh-token")
+                        .expiration(new Date(System.currentTimeMillis() + 86400000)).build();
+
+                RefreshToken existingToken =
+                        RefreshToken.builder().memberId(memberId).token("old-refresh-token")
+                                .expiration(new Date(System.currentTimeMillis() - 1000)).build();
+
+                when(refreshTokenRepository.findByMemberId(memberId))
+                        .thenReturn(Optional.of(existingToken));
+
+                // when
+                authService.saveRefreshTokenToRepository(memberId, newTokenInfo);
+
+                // then
+                verify(refreshTokenRepository, times(1)).findByMemberId(memberId);
+                verify(refreshTokenRepository, times(0)).save(any(RefreshToken.class));
+
+                // 기존 토큰이 업데이트되었는지 확인
+                assertThat(existingToken.getToken()).isEqualTo(newTokenInfo.getToken());
+                assertThat(existingToken.getExpiration()).isEqualTo(newTokenInfo.getExpiration());
+            }
+
+            @Test
+            @DisplayName("다른 memberId의 RefreshToken을 저장할 수 있다")
+            void saveRefreshToken_DifferentMemberId() {
+                // given
+                Long differentMemberId = 999L;
+                TokenInfo tokenInfo = TokenInfo.builder().token("different-refresh-token")
+                        .expiration(new Date(System.currentTimeMillis() + 86400000)).build();
+
+                when(refreshTokenRepository.findByMemberId(differentMemberId)).thenReturn(Optional.empty());
+                when(refreshTokenRepository.save(any(RefreshToken.class)))
+                        .thenReturn(RefreshToken.builder().memberId(differentMemberId)
+                                .token(tokenInfo.getToken()).expiration(tokenInfo.getExpiration()).build());
+
+                // when
+                authService.saveRefreshTokenToRepository(differentMemberId, tokenInfo);
+
+                // then
+                verify(refreshTokenRepository, times(1)).findByMemberId(differentMemberId);
+                verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("로그아웃 테스트")
     class LogoutTest {
 


### PR DESCRIPTION
# 🚀 What’s this PR about?

- **작업 내용 요약:** 이 PR에서 해결하거나 추가한 내용을 간략히 설명해 주세요.
  - 토큰 저장 로직에 대한 테스트 코드를 작성했다.

# 🛠️ What’s been done?

- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  해당사항 없음

# 🧪 Testing Details
## 테스트 케이스 목록
```
AuthServiceTest
AuthServiceTest
├── 로그인 테스트
│   ├── 정상 시나리오
│   │   ├── 정상적인 로그인 요청 시 성공적으로 로그인한다
│   │   ├── 다른 회원으로 로그인 시 올바른 정보가 반환된다
│   │   └── 토큰이 올바르게 생성된다
│   └── 예외 시나리오
│       ├── 존재하지 않는 이메일로 로그인 시 EMAIL_INVALID_EXCEPTION이 발생한다
│       ├── 빈 이메일로 로그인 시 EMAIL_INVALID_EXCEPTION이 발생한다
│       ├── null 이메일로 로그인 시 EMAIL_INVALID_EXCEPTION이 발생한다
│       ├── 잘못된 비밀번호로 로그인 시 PASSWORD_INVALID_EXCEPTION이 발생한다
│       ├── 빈 비밀번호로 로그인 시 PASSWORD_INVALID_EXCEPTION이 발생한다
│       └── null 비밀번호로 로그인 시 PASSWORD_INVALID_EXCEPTION이 발생한다
├── 토큰저장 테스트
│   ├── AccessToken 저장 테스트
│   │   ├── 새로운 AccessToken을 저장할 수 있다
│   │   ├── 기존 AccessToken을 업데이트할 수 있다
│   │   └── 다른 memberId의 AccessToken을 저장할 수 있다
│   ├── RefreshToken 저장 테스트
│   │   ├── 새로운 RefreshToken을 저장할 수 있다
│   │   ├── 기존 RefreshToken을 업데이트할 수 있다
│   │   └── 다른 memberId의 RefreshToken을 저장할 수 있다
└── 로그아웃 테스트
    ├── 정상 시나리오
    │   ├── 정상적인 로그아웃 시 토큰이 초기화된다
    │   └── 다른 memberId로 로그아웃할 수 있다
    └── 예외 시나리오
        └── RefreshToken이 존재하지 않을 때 TOKEN_NOT_FOUND_IN_DB 예외가 발생한다
``` 
## 테스트 커버리지 및 성공 여부
### 테스트 커버리지
![token-save-test-coverage](https://github.com/user-attachments/assets/6835fa2d-a72f-4932-bb67-3f332eba1b45)
### 테스트 결과
![token-save-result](https://github.com/user-attachments/assets/5345fb1f-04cf-40e7-9907-34dea0d25eff)

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

- 관련된 이슈를 연결하세요. (예: closes #이슈번호)
  #164 