### PR TITLE
[feat] AccessToken에서 id 추출 어노테이션 추가 

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/_global/config/WebConfig.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/_global/config/WebConfig.java
@@ -1,8 +1,11 @@
 package git_kkalnane.backend.starbucks._global.config;
 
+import git_kkalnane.backend.starbucks.auth.common.resolver.CurrentMemberIdArgumentResolver;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -12,6 +15,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final AuthInterceptor authInterceptor;
+    private final CurrentMemberIdArgumentResolver currentMemberIdArgumentResolver;
+
 
     @Value("${cors.allowed-origins}")
     private String allowedOrigins;
@@ -50,5 +55,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .exposedHeaders("Authorization", "Set-Cookie")    // 서버가 프론트엔드로 응답을 보낼 시 노출할 헤더를 지정하는 메서드
                 .allowCredentials(true)                           // 클라이언트가 서버로 요청을 보낼 시 허용할 자격 증명 허용 여부를 지정하는 메서드
                 .maxAge(maxAge);                                  // preflight 요청의 캐시 시간을 지정하는 메서드
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentMemberIdArgumentResolver);
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/auth/common/annotation/CurrentMemberId.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/auth/common/annotation/CurrentMemberId.java
@@ -1,0 +1,15 @@
+package git_kkalnane.backend.starbucks.auth.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Controller 메서드의 파라미터에 사용되며, 현재 인증된 사용자의 ID를 주입받기 위한 어노테이션입니다.
+ * 이 어노테이션이 붙은 파라미터에는 JWT 토큰에서 추출한 memberId가 자동으로 주입됩니다.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentMemberId {
+}

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/auth/common/exception/AuthErrorCode.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/auth/common/exception/AuthErrorCode.java
@@ -19,6 +19,7 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "위변조된 토큰입니다."),
     // 헤더에서 토큰을 추출할 때 사용
     MISSING_PREFIX(HttpStatus.BAD_REQUEST, "Authorization 헤더에 Bearer가 포함되어 있지 않습니다."),
+    INVALID_AUTH_HEADER(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 헤더입니다."),
     // 토큰 관련 - 주로 JwtTokenProvider에서 사용
     MALFORMED_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰 형식입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/auth/common/resolver/CurrentMemberIdArgumentResolver.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/auth/common/resolver/CurrentMemberIdArgumentResolver.java
@@ -1,0 +1,52 @@
+package git_kkalnane.backend.starbucks.auth.common.resolver;
+
+import git_kkalnane.backend.starbucks.auth.common.annotation.CurrentMemberId;
+import git_kkalnane.backend.starbucks.auth.common.exception.AuthErrorCode;
+import git_kkalnane.backend.starbucks.auth.common.exception.AuthException;
+import git_kkalnane.backend.starbucks.auth.common.jwt.JwtTokenProvider;
+import git_kkalnane.backend.starbucks.auth.common.jwt.utils.TokenParser;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * @CurrentMemberId 어노테이션이 붙은 파라미터에 현재 인증된 사용자의 ID를 주입하기 위한 리졸버
+ */
+@Component
+@RequiredArgsConstructor
+public class CurrentMemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentMemberId.class) &&
+               parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                 NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorizationHeader == null || !authorizationHeader.startsWith(TokenParser.ACCESS_PREFIX_STRING)) {
+            throw new AuthException(AuthErrorCode.MISSING_PREFIX);
+        }
+
+        String token = authorizationHeader.substring(TokenParser.ACCESS_PREFIX_STRING.length());
+        String memberIdStr = jwtTokenProvider.getMemberId(token);
+        
+        try {
+            return Long.parseLong(memberIdStr);
+        } catch (NumberFormatException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/auth/common/resolver/CurrentMemberIdArgumentResolverTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/auth/common/resolver/CurrentMemberIdArgumentResolverTest.java
@@ -1,0 +1,150 @@
+package git_kkalnane.backend.starbucks.auth.common.resolver;
+
+import git_kkalnane.backend.starbucks.auth.common.annotation.CurrentMemberId;
+import git_kkalnane.backend.starbucks.auth.common.exception.AuthErrorCode;
+import git_kkalnane.backend.starbucks.auth.common.jwt.JwtTokenProvider;
+import git_kkalnane.backend.starbucks.auth.common.exception.AuthException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CurrentMemberIdArgumentResolverTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private MethodParameter parameter;
+
+    @Mock
+    private ModelAndViewContainer mavContainer;
+
+    @InjectMocks
+    private CurrentMemberIdArgumentResolver resolver;
+
+    private NativeWebRequest webRequest;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        webRequest = new ServletWebRequest(request);
+    }
+
+    @Test
+    @DisplayName("supportsParameter - @CurrentMemberId가 있고 타입이 Long인 경우 true 반환")
+    void supportsParameter_WhenAnnotationPresentAndTypeIsLong_ReturnsTrue() {
+        // given
+        when(parameter.hasParameterAnnotation(CurrentMemberId.class)).thenReturn(true);
+        when(parameter.getParameterType()).thenReturn((Class) Long.class);
+
+        // when
+        boolean result = resolver.supportsParameter(parameter);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("supportsParameter - @CurrentMemberId가 없으면 false 반환")
+    void supportsParameter_WhenAnnotationNotPresent_ReturnsFalse() {
+        // given
+        when(parameter.hasParameterAnnotation(CurrentMemberId.class)).thenReturn(false);
+
+        // when
+        boolean result = resolver.supportsParameter(parameter);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("supportsParameter - 타입이 Long이 아니면 false 반환")
+    void supportsParameter_WhenTypeIsNotLong_ReturnsFalse() {
+        // given
+        when(parameter.hasParameterAnnotation(CurrentMemberId.class)).thenReturn(true);
+        when(parameter.getParameterType()).thenReturn((Class) String.class);
+
+        // when
+        boolean result = resolver.supportsParameter(parameter);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("resolveArgument - 유효한 토큰인 경우 memberId 반환")
+    void resolveArgument_WithValidToken_ReturnsMemberId() {
+        // given
+        String validToken = "valid.token.here";
+        String expectedMemberId = "1";
+        
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + validToken);
+        when(jwtTokenProvider.getMemberId(validToken)).thenReturn(expectedMemberId);
+
+        // when
+        Long result = (Long) resolver.resolveArgument(
+                parameter, mavContainer, webRequest, null);
+
+        // then
+        assertEquals(1L, result);
+    }
+
+    @Test
+    @DisplayName("resolveArgument - Authorization 헤더가 없는 경우 예외 발생")
+    void resolveArgument_WhenNoAuthHeader_ThrowsException() {
+        // given - No Authorization header set
+        
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () ->
+            resolver.resolveArgument(parameter, mavContainer, webRequest, null)
+        );
+        
+        assertEquals(AuthErrorCode.MISSING_PREFIX, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("resolveArgument - Bearer 접두사가 없는 경우 예외 발생")
+    void resolveArgument_WhenNoBearerPrefix_ThrowsException() {
+        // given
+        request.addHeader(HttpHeaders.AUTHORIZATION, "InvalidToken");
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class, () ->
+            resolver.resolveArgument(parameter, mavContainer, webRequest, null)
+        );
+        
+        assertEquals(AuthErrorCode.MISSING_PREFIX, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("resolveArgument - 토큰이 유효하지 않은 경우 예외 발생")
+    void resolveArgument_WhenTokenIsInvalid_ThrowsException() {
+        // given
+        String invalidToken = "invalid.token";
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + invalidToken);
+        
+        when(jwtTokenProvider.getMemberId(invalidToken))
+            .thenThrow(new AuthException(AuthErrorCode.INVALID_TOKEN));
+
+        // when & then
+        assertThrows(AuthException.class, () ->
+            resolver.resolveArgument(parameter, mavContainer, webRequest, null)
+        );
+    }
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?

- **작업 내용 요약:** 이 PR에서 해결하거나 추가한 내용을 간략히 설명해 주세요.
1. AccessToken을 사용 API에서 member의 id가 필요할때 사용할 어노테이션 

# 🛠️ What’s been done?

- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  - 변경된 로직이나 구조 설명

# 🧪 Testing Details

- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 테스트 커버리지 및 성공 여부
  - 추가적인 검증이 필요한 시나리오

1. supportsParameter - @CurrentMemberId가 있고 타입이 Long인 경우 true 반환
2. supportsParameter - @CurrentMemberId가 없으면 false 반환
3. upportsParameter - 타입이 Long이 아니면 false 반환


![image](https://github.com/user-attachments/assets/96b36ebc-dc4a-404d-8ba4-45e59792c97f)

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

- 관련된 이슈를 연결하세요. (예: closes #이슈번호)
#198
