### PR TITLE
[feat] 사용자 상세정보 조회, 사용자 닉네임 갱신, 사용자 비밀번호 갱신 로직 구현

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/common/success/MemberSuccessCode.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/common/success/MemberSuccessCode.java
@@ -9,8 +9,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberSuccessCode implements SuccessCode {
     SIGN_UP_COMPLETED(HttpStatus.CREATED, "회원가입이 성공적으로 완료 되었습니다."),
-    MEMBER_FETCH_COMPLETE(HttpStatus.OK,"멤버 프로필 조회에 성공했습니다."),
-    MEMBER_UPDATE_COMPLETE(HttpStatus.OK,"프로필이 성공적으로 업데이트되었습니다."),
+    GET_MEMBER_DETAIL_INFO_COMPLETE(HttpStatus.OK,"멤버 프로필 조회에 성공했습니다."),
+    MEMBER_NICKNAME_UPDATE_COMPLETE(HttpStatus.OK,"닉네임이 성공적으로 업데이트되었습니다."),
+    MEMBER_PASSWORD_UPDATE_COMPLETE(HttpStatus.OK, "비밀번호가 성공적으로 업데이트 되었습니다."),
     MEMBER_DELETE_COMPLETE(HttpStatus.OK,"회원 탈퇴에 성공하였습니다.");
 
     private final HttpStatus status;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/controller/MemberController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/controller/MemberController.java
@@ -4,6 +4,8 @@ package git_kkalnane.backend.starbucks.member.controller;
 import git_kkalnane.backend.starbucks._global.success.SuccessResponse;
 import git_kkalnane.backend.starbucks.member.common.success.MemberSuccessCode;
 import git_kkalnane.backend.starbucks.member.dto.request.SignUpRequest;
+import git_kkalnane.backend.starbucks.member.dto.request.UpdateNicknameRequest;
+import git_kkalnane.backend.starbucks.member.dto.request.UpdatePasswordRequest;
 import git_kkalnane.backend.starbucks.member.dto.response.MemberDetailInfo;
 import git_kkalnane.backend.starbucks.member.dto.response.SignUpResponse;
 import git_kkalnane.backend.starbucks.member.service.MemberService;
@@ -80,6 +82,33 @@ public class MemberController {
 
         return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.GET_MEMBER_DETAIL_INFO_COMPLETE,
                 memberService.getMemberDetailInfo(memberId)));
+    }
+
+    /**
+     * HTTP Request 속성에 있는 멤버 ID를 이용해 멤버의 닉네임을 변경하는 컨트롤러 메서드이다.
+     */
+    @Operation(
+            summary = "멤버 닉네임 갱신",
+            description = "멤버 닉네임을 갱신 시 사용하는 API"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "멤버 닉네임이 성공적으로 갱신됨"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 멤버를 찾을 수 없음"
+            )
+    })
+    @PostMapping("/update/nickname")
+    public ResponseEntity<SuccessResponse<?>> updateNickname(
+            @RequestAttribute(name = "memberId") Long memberId,
+            @RequestBody @Valid UpdateNicknameRequest request) {
+
+        memberService.updateNickname(memberId, request);
+
+        return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_NICKNAME_UPDATE_COMPLETE));
     }
 
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/controller/MemberController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/controller/MemberController.java
@@ -111,4 +111,31 @@ public class MemberController {
         return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_NICKNAME_UPDATE_COMPLETE));
     }
 
+    /**
+     * HTTP Request 속성에 있는 멤버 ID를 이용해 멤버의 비밀번호를 변경하는 컨트롤러 메서드이다.
+     */
+    @Operation(
+            summary = "멤버 비밀번호 갱신",
+            description = "멤버 비밀번호를 갱신 시 사용하는 API"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "멤버 비밀번호가 성공적으로 갱신됨"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 멤버를 찾을 수 없음"
+            )
+    })
+    @PostMapping("/update/password")
+    public ResponseEntity<SuccessResponse<?>> updatePassword(
+            @RequestAttribute(name = "memberId") Long memberId,
+            @RequestBody @Valid UpdatePasswordRequest request) {
+
+        memberService.updatePassword(memberId, request);
+
+        return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_PASSWORD_UPDATE_COMPLETE));
+    }
+
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/controller/MemberController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/controller/MemberController.java
@@ -4,19 +4,18 @@ package git_kkalnane.backend.starbucks.member.controller;
 import git_kkalnane.backend.starbucks._global.success.SuccessResponse;
 import git_kkalnane.backend.starbucks.member.common.success.MemberSuccessCode;
 import git_kkalnane.backend.starbucks.member.dto.request.SignUpRequest;
+import git_kkalnane.backend.starbucks.member.dto.response.MemberDetailInfo;
 import git_kkalnane.backend.starbucks.member.dto.response.SignUpResponse;
 import git_kkalnane.backend.starbucks.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,16 +47,39 @@ public class MemberController {
                     description = "이미 존재하는 이메일, 이름 길이 초과, 사용자 성명 규칙 위배"
             )
     })
-    @Parameters({
-            @Parameter(name = "name", description = "회원 이름", example = "홍길동"),
-            @Parameter(name = "nickname", description = "닉네임", example = "나는야홍길동"),
-            @Parameter(name = "email", description = "회원 이메일", example = "user0123@gmail.com"),
-            @Parameter(name = "password", description = "비밀번호", example = "password0123")
-    })
     @PostMapping("/signup")
     public ResponseEntity<SuccessResponse<SignUpResponse>> signup(@RequestBody @Valid SignUpRequest request) {
 
         return ResponseEntity.ok(
                 (SuccessResponse.of(MemberSuccessCode.SIGN_UP_COMPLETED, memberService.createMember(request))));
     }
+
+    /**
+     * HTTP Request 속성에 있는 멤버 ID를 이용해 멤버 상세 정보를 조회하는 컨트롤러 메서드이다.
+     *
+     * @param memberId 사용자 엔티티 식별자 (ID)
+     * @return {@link MemberDetailInfo} 객체
+     */
+    @Operation(
+            summary = "멤버 상세 정보 조회",
+            description = "멤버 상세 정보를 조회 시 사용하는 API"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "멤버 상세 정보가 성공적으로 조회됨"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 멤버를 찾을 수 없음"
+            )
+    })
+    @GetMapping("/info")
+    public ResponseEntity<SuccessResponse<MemberDetailInfo>> getMemberDetailInfo(
+            @RequestAttribute(name = "memberId") Long memberId) {
+
+        return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.GET_MEMBER_DETAIL_INFO_COMPLETE,
+                memberService.getMemberDetailInfo(memberId)));
+    }
+
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/domain/Member.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/domain/Member.java
@@ -46,4 +46,12 @@ public class Member extends BaseTimeEntity {
         this.email = email;
         this.password = password;
     }
+
+    public void modifyNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void modifyPassword(String password) {
+        this.password = password;
+    }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/dto/request/SignUpRequest.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/dto/request/SignUpRequest.java
@@ -4,6 +4,7 @@ import git_kkalnane.backend.starbucks.member.validation.annotation.ValidEmail;
 import git_kkalnane.backend.starbucks.member.validation.annotation.ValidName;
 import git_kkalnane.backend.starbucks.member.validation.annotation.ValidNickname;
 import git_kkalnane.backend.starbucks.member.validation.annotation.ValidPassword;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * 회원가입 요청 시 프론트엔드 측에서 넘어오는 데이터를 담기 위한 DTO
@@ -13,17 +14,22 @@ import git_kkalnane.backend.starbucks.member.validation.annotation.ValidPassword
  * @param email    가입자 이메일
  * @param password 가입자 비밀번호
  */
+@Schema(title = "회원가입 요청 DTO")
 public record SignUpRequest(
 
         @ValidName
+        @Schema(description = "사용자 이름", example = "홍길동")
         String name,
 
         @ValidNickname
+        @Schema(description = "사용자 닉네임", example = "나는야홍길동")
         String nickname,
 
         @ValidEmail
+        @Schema(description = "사용자 이메일", example = "hong0123@gmail.com")
         String email,
 
         @ValidPassword
+        @Schema(description = "비밀번호", example = "@Hong12345#")
         String password) {
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/dto/request/UpdateNicknameRequest.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/dto/request/UpdateNicknameRequest.java
@@ -1,0 +1,17 @@
+package git_kkalnane.backend.starbucks.member.dto.request;
+
+import git_kkalnane.backend.starbucks.member.validation.annotation.ValidNickname;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 사용자 닉네임 변경 요청 DTO
+ *
+ * @param nickname 변경할 닉네임
+ */
+@Schema(title = "닉네임 변경 요청 DTO")
+public record UpdateNicknameRequest(
+
+        @ValidNickname
+        @Schema(description = "변경할 닉네임", example = "가나다라마바")
+        String nickname) {
+}

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/dto/request/UpdatePasswordRequest.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,17 @@
+package git_kkalnane.backend.starbucks.member.dto.request;
+
+import git_kkalnane.backend.starbucks.member.validation.annotation.ValidPassword;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 사용자 비밀번호 변경 요청 DTO
+ *
+ * @param password 변경할 비밀번호
+ */
+@Schema(title = "비밀번호 변경 요청 DTO")
+public record UpdatePasswordRequest(
+
+        @ValidPassword
+        @Schema(description = "변경할 비밀번호", example = "@Hong12345#")
+        String password) {
+}

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/dto/response/MemberDetailInfo.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/dto/response/MemberDetailInfo.java
@@ -1,0 +1,27 @@
+package git_kkalnane.backend.starbucks.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 멤버 상세 정보 응답 DTO
+ *
+ * @param name 사용자 이름
+ * @param email 사용자 이메일
+ * @param nickname 사용자 닉네임
+ */
+@Schema(title = "멤버 상세 정보 응답 DTO")
+public record MemberDetailInfo(
+
+        @Schema(description = "사용자 이름", example = "홍길동")
+        String name,
+
+        @Schema(description = "사용자 이메일", example = "example@gmail.com")
+        String email,
+
+        @Schema(description = "사용자 닉네임", example = "가나다라마바")
+        String nickname) {
+
+    public static MemberDetailInfo of(String name, String email, String nickname) {
+        return new MemberDetailInfo(name, email, nickname);
+    }
+}

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/service/MemberService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/service/MemberService.java
@@ -71,4 +71,18 @@ public class MemberService {
         return MemberDetailInfo.of(member.getName(), member.getEmail(), member.getNickname());
     }
 
+    /**
+     * 매개변수로 들어온 멤버 엔티티 식별자(ID)를 바탕으로 멤버의 닉네임을 변경하는 메서드
+     *
+     * @param memberId 사용자 엔티티 식별자 (ID)
+     * @param request
+     */
+    @Transactional
+    public void updateNickname(Long memberId, UpdateNicknameRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        member.modifyNickname(request.nickname());
+    }
+
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/service/MemberService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/service/MemberService.java
@@ -5,6 +5,9 @@ import git_kkalnane.backend.starbucks.member.common.exception.MemberErrorCode;
 import git_kkalnane.backend.starbucks.member.common.exception.MemberException;
 import git_kkalnane.backend.starbucks.member.domain.Member;
 import git_kkalnane.backend.starbucks.member.dto.request.SignUpRequest;
+import git_kkalnane.backend.starbucks.member.dto.request.UpdateNicknameRequest;
+import git_kkalnane.backend.starbucks.member.dto.request.UpdatePasswordRequest;
+import git_kkalnane.backend.starbucks.member.dto.response.MemberDetailInfo;
 import git_kkalnane.backend.starbucks.member.dto.response.SignUpResponse;
 import git_kkalnane.backend.starbucks.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -54,4 +57,18 @@ public class MemberService {
             throw new MemberException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
         }
     }
+
+    /**
+     * 매개변수로 들어온 멤버 엔티티 식별자(ID)를 바탕으로 사용자 정보를 DB에서 찾아내어 반환하는 메서드
+     *
+     * @param memberId 사용자 엔티티 식별자 (ID)
+     * @return {@link MemberDetailInfo} 객체
+     */
+    public MemberDetailInfo getMemberDetailInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        return MemberDetailInfo.of(member.getName(), member.getEmail(), member.getNickname());
+    }
+
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/service/MemberService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/service/MemberService.java
@@ -75,7 +75,7 @@ public class MemberService {
      * 매개변수로 들어온 멤버 엔티티 식별자(ID)를 바탕으로 멤버의 닉네임을 변경하는 메서드
      *
      * @param memberId 사용자 엔티티 식별자 (ID)
-     * @param request
+     * @param request {@link UpdateNicknameRequest}
      */
     @Transactional
     public void updateNickname(Long memberId, UpdateNicknameRequest request) {
@@ -89,7 +89,7 @@ public class MemberService {
      * 매개변수로 들어온 멤버 엔티티 식별자(ID)를 바탕으로 멤버의 비밀번호를 변경하는 메서드
      *
      * @param memberId 사용자 엔티티 식별자 (ID)
-     * @param request
+     * @param request {@link UpdatePasswordRequest}
      */
     @Transactional
     public void updatePassword(Long memberId, UpdatePasswordRequest request) {

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/service/MemberService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/member/service/MemberService.java
@@ -85,4 +85,19 @@ public class MemberService {
         member.modifyNickname(request.nickname());
     }
 
+    /**
+     * 매개변수로 들어온 멤버 엔티티 식별자(ID)를 바탕으로 멤버의 비밀번호를 변경하는 메서드
+     *
+     * @param memberId 사용자 엔티티 식별자 (ID)
+     * @param request
+     */
+    @Transactional
+    public void updatePassword(Long memberId, UpdatePasswordRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        String encryptedPassword = encryptor.encrypt(request.password());
+
+        member.modifyPassword(encryptedPassword);
+    }
 }

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/member/service/MemberServiceTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/member/service/MemberServiceTest.java
@@ -13,9 +13,13 @@ import git_kkalnane.backend.starbucks.member.common.exception.MemberErrorCode;
 import git_kkalnane.backend.starbucks.member.common.exception.MemberException;
 import git_kkalnane.backend.starbucks.member.domain.Member;
 import git_kkalnane.backend.starbucks.member.dto.request.SignUpRequest;
+import git_kkalnane.backend.starbucks.member.dto.request.UpdateNicknameRequest;
+import git_kkalnane.backend.starbucks.member.dto.request.UpdatePasswordRequest;
+import git_kkalnane.backend.starbucks.member.dto.response.MemberDetailInfo;
 import git_kkalnane.backend.starbucks.member.dto.response.SignUpResponse;
 import git_kkalnane.backend.starbucks.member.repository.MemberRepository;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -53,258 +57,736 @@ class MemberServiceTest {
     }
 
     @Nested
-    @DisplayName("성공 시나리오")
-    class SuccessTest {
-        @Test
-        @DisplayName("정상적인 회원가입 요청 시 성공적으로 회원을 생성한다")
-        void createMember_Success() {
-            // given
-            when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+    @DisplayName("회원가입 테스트")
+    class SignUpTest {
 
-            // when
-            SignUpResponse response = memberService.createMember(signUpRequest);
+        @Nested
+        @DisplayName("성공 시나리오")
+        class SuccessTest {
+            @Test
+            @DisplayName("정상적인 회원가입 요청 시 성공적으로 회원을 생성한다")
+            void createMember_Success() {
+                // given
+                when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
 
-            // then
-            assertThat(response).isNotNull();
-            assertThat(response.name()).isEqualTo(signUpRequest.name());
-            verify(memberRepository, times(1)).save(any(Member.class));
+                // when
+                SignUpResponse response = memberService.createMember(signUpRequest);
+
+                // then
+                assertThat(response).isNotNull();
+                assertThat(response.name()).isEqualTo(signUpRequest.name());
+                verify(memberRepository, times(1)).save(any(Member.class));
+            }
+
+            @Test
+            @DisplayName("회원가입 시 비밀번호가 올바르게 암호화된다")
+            void createMember_PasswordEncryption() {
+                // given
+                when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+                // when
+                memberService.createMember(signUpRequest);
+
+                // then
+                verify(memberRepository, times(1)).save(argThat(
+                        member -> encryptor.isMatch(signUpRequest.password(), member.getPassword())));
+            }
+
+            @Test
+            @DisplayName("회원가입 시 Member 엔티티가 올바른 정보로 생성된다")
+            void createMember_CorrectMemberEntity() {
+                // given
+                when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+                // when
+                memberService.createMember(signUpRequest);
+
+                // then
+                verify(memberRepository, times(1))
+                        .save(argThat(member -> member.getName().equals(signUpRequest.name())
+                                && member.getNickname().equals(signUpRequest.nickname())
+                                && member.getEmail().equals(signUpRequest.email())
+                                && encryptor.isMatch(signUpRequest.password(), member.getPassword())));
+            }
+
+            @Test
+            @DisplayName("여러 회원을 연속으로 생성할 때 각각 올바르게 처리된다")
+            void createMember_MultipleMembers() {
+                // given
+                SignUpRequest request1 =
+                        new SignUpRequest("김철수", "철수", "user1@example.com", "password1");
+                SignUpRequest request2 =
+                        new SignUpRequest("김영희", "영희", "user2@example.com", "password2");
+
+                String encryptedPassword1 = encryptor.encrypt(request1.password());
+                String encryptedPassword2 = encryptor.encrypt(request2.password());
+
+                Member member1 = Member.builder()
+                        .name(request1.name())
+                        .nickname(request1.nickname())
+                        .email(request1.email())
+                        .password(encryptedPassword1)
+                        .build();
+
+                Member member2 = Member.builder()
+                        .name(request2.name())
+                        .nickname(request2.nickname())
+                        .email(request2.email())
+                        .password(encryptedPassword2)
+                        .build();
+
+                when(memberRepository.save(any(Member.class))).thenReturn(member1).thenReturn(member2);
+
+                // when
+                SignUpResponse response1 = memberService.createMember(request1);
+                SignUpResponse response2 = memberService.createMember(request2);
+
+                // then
+                assertThat(response1.name()).isEqualTo("김철수");
+                assertThat(response2.name()).isEqualTo("김영희");
+                verify(memberRepository, times(2)).save(any(Member.class));
+            }
+
+            @Test
+            @DisplayName("다른 비밀번호로 회원가입 시 다른 해시값이 생성된다")
+            void createMember_DifferentPasswordsGenerateDifferentHashes() {
+                // given
+                SignUpRequest request1 =
+                        new SignUpRequest("김철수", "철수", "user1@example.com", "password1");
+                SignUpRequest request2 =
+                        new SignUpRequest("김영희", "영희", "user2@example.com", "password2");
+
+                when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+                // when
+                memberService.createMember(request1);
+                memberService.createMember(request2);
+
+                // then
+                ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+                verify(memberRepository, times(2)).save(memberCaptor.capture());
+
+                List<Member> savedMembers = memberCaptor.getAllValues();
+
+                // 각각의 비밀번호가 올바르게 암호화되었는지 확인
+                assertThat(encryptor.isMatch(request1.password(), savedMembers.get(0).getPassword())).isTrue();
+                assertThat(encryptor.isMatch(request2.password(), savedMembers.get(1).getPassword())).isTrue();
+
+                // 두 해시값이 서로 다른지 확인
+                assertThat(savedMembers.get(0).getPassword())
+                        .isNotEqualTo(savedMembers.get(1).getPassword());
+            }
+
+            @Test
+            @DisplayName("같은 비밀번호라도 매번 다른 해시값이 생성된다")
+            void createMember_SamePasswordGeneratesDifferentHashes() {
+                // given
+                SignUpRequest request1 =
+                        new SignUpRequest("김철수", "철수", "user1@example.com", "password123");
+                SignUpRequest request2 =
+                        new SignUpRequest("김영희", "영희", "user2@example.com", "password123");
+
+                when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+                // when
+                memberService.createMember(request1);
+                memberService.createMember(request2);
+
+                // then
+                ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+                verify(memberRepository, times(2)).save(memberCaptor.capture());
+
+                List<Member> savedMembers = memberCaptor.getAllValues();
+
+                // 두 비밀번호가 모두 올바르게 암호화되었는지 확인
+                assertThat(encryptor.isMatch("password123", savedMembers.get(0).getPassword())).isTrue();
+                assertThat(encryptor.isMatch("password123", savedMembers.get(1).getPassword())).isTrue();
+
+                // 같은 비밀번호이지만 해시값은 서로 다른지 확인 (BCrypt의 salt 특성)
+                assertThat(savedMembers.get(0).getPassword()).isNotEqualTo(savedMembers.get(1).getPassword());
+            }
         }
 
-        @Test
-        @DisplayName("회원가입 시 비밀번호가 올바르게 암호화된다")
-        void createMember_PasswordEncryption() {
-            // given
-            when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+        @Nested
+        @DisplayName("예외 시나리오")
+        class ExceptionTest {
+            @Test
+            @DisplayName("Repository save 실패 시 예외가 발생한다")
+            void createMember_RepositorySaveFailure() {
+                // given
+                when(memberRepository.save(any(Member.class))).thenThrow(new RuntimeException("Database error"));
 
-            // when
-            memberService.createMember(signUpRequest);
+                // when & then
+                assertThatThrownBy(() -> memberService.createMember(signUpRequest))
+                        .isInstanceOf(RuntimeException.class)
+                        .hasMessage("Database error");
+            }
 
-            // then
-            verify(memberRepository, times(1)).save(argThat(
-                    member -> encryptor.isMatch(signUpRequest.password(), member.getPassword())));
-        }
+            @Test
+            @DisplayName("중복된 이메일로 회원가입 시 MemberException이 발생한다")
+            void createMember_DuplicatedEmail() {
+                // given
+                when(memberRepository.existsByEmail(signUpRequest.email())).thenReturn(true);
 
-        @Test
-        @DisplayName("회원가입 시 Member 엔티티가 올바른 정보로 생성된다")
-        void createMember_CorrectMemberEntity() {
-            // given
-            when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+                // when & then
+                assertThatThrownBy(() -> memberService.createMember(signUpRequest))
+                        .isInstanceOf(MemberException.class)
+                        .satisfies(exception -> {
+                            MemberException memberException =
+                                    (MemberException) exception;
+                            assertThat(memberException.getErrorCode())
+                                    .isEqualTo(MemberErrorCode.EMAIL_ALREADY_EXISTS);
+                        });
 
-            // when
-            memberService.createMember(signUpRequest);
+                // verify
+                verify(memberRepository, times(1)).existsByEmail(signUpRequest.email());
+                verify(memberRepository, times(0)).save(any(Member.class)); // save는 호출되지
+                // 않아야 함
+            }
 
-            // then
-            verify(memberRepository, times(1))
-                    .save(argThat(member -> member.getName().equals(signUpRequest.name())
-                            && member.getNickname().equals(signUpRequest.nickname())
-                            && member.getEmail().equals(signUpRequest.email())
-                            && encryptor.isMatch(signUpRequest.password(), member.getPassword())));
-        }
+            @Test
+            @DisplayName("이미 존재하는 이메일로 회원가입 시 예외 메시지가 올바르다")
+            void createMember_DuplicatedEmail_CorrectMessage() {
+                // given
+                when(memberRepository.existsByEmail(signUpRequest.email()))
+                        .thenReturn(true);
 
-        @Test
-        @DisplayName("여러 회원을 연속으로 생성할 때 각각 올바르게 처리된다")
-        void createMember_MultipleMembers() {
-            // given
-            SignUpRequest request1 =
-                    new SignUpRequest("김철수", "철수", "user1@example.com", "password1");
-            SignUpRequest request2 =
-                    new SignUpRequest("김영희", "영희", "user2@example.com", "password2");
+                // when & then
+                assertThatThrownBy(() -> memberService.createMember(signUpRequest))
+                        .isInstanceOf(MemberException.class)
+                        .hasMessage("이미 존재하는 이메일입니다.");
+            }
 
-            String encryptedPassword1 = encryptor.encrypt(request1.password());
-            String encryptedPassword2 = encryptor.encrypt(request2.password());
+            @Test
+            @DisplayName("서로 다른 이메일의 중복 검사가 독립적으로 작동한다")
+            void createMember_DifferentEmailsValidation() {
+                // given
+                SignUpRequest request1 =
+                        new SignUpRequest("김철수", "철수", "existing@example.com", "password1");
+                SignUpRequest request2 =
+                        new SignUpRequest("김영희", "영희", "new@example.com", "password2");
 
-            Member member1 = Member.builder().name(request1.name()).nickname(request1.nickname())
-                    .email(request1.email()).password(encryptedPassword1).build();
+                // existing@example.com은 이미 존재, new@example.com은 존재하지 않음
+                when(memberRepository.existsByEmail("existing@example.com")).thenReturn(true);
+                when(memberRepository.existsByEmail("new@example.com")).thenReturn(false);
+                when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
 
-            Member member2 = Member.builder().name(request2.name()).nickname(request2.nickname())
-                    .email(request2.email()).password(encryptedPassword2).build();
+                // when & then
+                // 첫 번째 요청은 예외 발생
+                assertThatThrownBy(() -> memberService.createMember(request1))
+                        .isInstanceOf(MemberException.class)
+                        .satisfies(exception -> {
+                            MemberException memberException =
+                                    (MemberException) exception;
+                            assertThat(memberException.getErrorCode())
+                                    .isEqualTo(MemberErrorCode.EMAIL_ALREADY_EXISTS);
+                        });
 
-            when(memberRepository.save(any(Member.class))).thenReturn(member1).thenReturn(member2);
+                // 두 번째 요청은 성공
+                SignUpResponse response = memberService.createMember(request2);
+                assertThat(response).isNotNull();
 
-            // when
-            SignUpResponse response1 = memberService.createMember(request1);
-            SignUpResponse response2 = memberService.createMember(request2);
+                // verify
+                verify(memberRepository, times(1)).existsByEmail("existing@example.com");
+                verify(memberRepository, times(1)).existsByEmail("new@example.com");
+                verify(memberRepository, times(1)).save(any(Member.class)); // 두 번째 요청에서만
+                // save 호출
+            }
 
-            // then
-            assertThat(response1.name()).isEqualTo("김철수");
-            assertThat(response2.name()).isEqualTo("김영희");
-            verify(memberRepository, times(2)).save(any(Member.class));
-        }
+            @Test
+            @DisplayName("null 이메일로 회원가입 시도 시 existsByEmail이 호출된다")
+            void createMember_NullEmail() {
+                // given
+                SignUpRequest nullEmailRequest =
+                        new SignUpRequest("홍길동", "길동", null, "password123");
+                when(memberRepository.existsByEmail(null)).thenReturn(false); // null에 대해서는
+                // false 반환
+                when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
 
-        @Test
-        @DisplayName("다른 비밀번호로 회원가입 시 다른 해시값이 생성된다")
-        void createMember_DifferentPasswordsGenerateDifferentHashes() {
-            // given
-            SignUpRequest request1 =
-                    new SignUpRequest("김철수", "철수", "user1@example.com", "password1");
-            SignUpRequest request2 =
-                    new SignUpRequest("김영희", "영희", "user2@example.com", "password2");
+                // when
+                SignUpResponse response = memberService.createMember(nullEmailRequest);
 
-            when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+                // then
+                assertThat(response).isNotNull();
+                verify(memberRepository, times(1)).existsByEmail(null);
+                verify(memberRepository, times(1)).save(any(Member.class));
+            }
 
-            // when
-            memberService.createMember(request1);
-            memberService.createMember(request2);
+            @Test
+            @DisplayName("빈 문자열 이메일로 회원가입 시도 시 existsByEmail이 호출된다")
+            void createMember_EmptyEmail() {
+                // given
+                SignUpRequest emptyEmailRequest =
+                        new SignUpRequest("홍길동", "길동", "", "password123");
+                when(memberRepository.existsByEmail("")).thenReturn(false);
+                when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
 
-            // then
-            ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
-            verify(memberRepository, times(2)).save(memberCaptor.capture());
+                // when
+                SignUpResponse response = memberService.createMember(emptyEmailRequest);
 
-            List<Member> savedMembers = memberCaptor.getAllValues();
-
-            // 각각의 비밀번호가 올바르게 암호화되었는지 확인
-            assertThat(encryptor.isMatch(request1.password(), savedMembers.get(0).getPassword()))
-                    .isTrue();
-            assertThat(encryptor.isMatch(request2.password(), savedMembers.get(1).getPassword()))
-                    .isTrue();
-
-            // 두 해시값이 서로 다른지 확인
-            assertThat(savedMembers.get(0).getPassword())
-                    .isNotEqualTo(savedMembers.get(1).getPassword());
-        }
-
-        @Test
-        @DisplayName("같은 비밀번호라도 매번 다른 해시값이 생성된다")
-        void createMember_SamePasswordGeneratesDifferentHashes() {
-            // given
-            SignUpRequest request1 =
-                    new SignUpRequest("김철수", "철수", "user1@example.com", "password123");
-            SignUpRequest request2 =
-                    new SignUpRequest("김영희", "영희", "user2@example.com", "password123");
-
-            when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
-
-            // when
-            memberService.createMember(request1);
-            memberService.createMember(request2);
-
-            // then
-            ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
-            verify(memberRepository, times(2)).save(memberCaptor.capture());
-
-            List<Member> savedMembers = memberCaptor.getAllValues();
-
-            // 두 비밀번호가 모두 올바르게 암호화되었는지 확인
-            assertThat(encryptor.isMatch("password123", savedMembers.get(0).getPassword()))
-                    .isTrue();
-            assertThat(encryptor.isMatch("password123", savedMembers.get(1).getPassword()))
-                    .isTrue();
-
-            // 같은 비밀번호이지만 해시값은 서로 다른지 확인 (BCrypt의 salt 특성)
-            assertThat(savedMembers.get(0).getPassword())
-                    .isNotEqualTo(savedMembers.get(1).getPassword());
+                // then
+                assertThat(response).isNotNull();
+                verify(memberRepository, times(1)).existsByEmail("");
+                verify(memberRepository, times(1)).save(any(Member.class));
+            }
         }
     }
 
     @Nested
-    @DisplayName("예외 시나리오")
-    class ExceptionTest {
-        @Test
-        @DisplayName("Repository save 실패 시 예외가 발생한다")
-        void createMember_RepositorySaveFailure() {
-            // given
-            when(memberRepository.save(any(Member.class)))
-                    .thenThrow(new RuntimeException("Database error"));
+    @DisplayName("회원 정보 조회 테스트")
+    class GetMemberDetailInfoTest {
 
-            // when & then
-            assertThatThrownBy(() -> memberService.createMember(signUpRequest))
-                    .isInstanceOf(RuntimeException.class).hasMessage("Database error");
+        @Nested
+        @DisplayName("성공 시나리오")
+        class SuccessTest {
+
+            @Test
+            @DisplayName("정상적인 memberId로 회원 정보를 조회할 수 있다")
+            void getMemberDetailInfo_Success() {
+                // given
+                Long memberId = 1L;
+                Member member = Member.builder().name("홍길동").nickname("길동이")
+                        .email("hong@example.com")
+                        .password("encrypted_password").build();
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                MemberDetailInfo result =
+                        memberService.getMemberDetailInfo(memberId);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.name()).isEqualTo("홍길동");
+                assertThat(result.nickname()).isEqualTo("길동이");
+                assertThat(result.email()).isEqualTo("hong@example.com");
+
+                verify(memberRepository, times(1)).findById(memberId);
+            }
+
+            @Test
+            @DisplayName("다른 memberId로 회원 정보를 조회할 수 있다")
+            void getMemberDetailInfo_DifferentMember() {
+                // given
+                Long memberId = 2L;
+                Member member = Member.builder().name("김철수").nickname("철수짱")
+                        .email("chulsoo@example.com")
+                        .password("encrypted_password2").build();
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                MemberDetailInfo result =
+                        memberService.getMemberDetailInfo(memberId);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.name()).isEqualTo("김철수");
+                assertThat(result.nickname()).isEqualTo("철수짱");
+                assertThat(result.email()).isEqualTo("chulsoo@example.com");
+
+                verify(memberRepository, times(1)).findById(memberId);
+            }
         }
 
-        @Test
-        @DisplayName("중복된 이메일로 회원가입 시 MemberException이 발생한다")
-        void createMember_DuplicatedEmail() {
-            // given
-            when(memberRepository.existsByEmail(signUpRequest.email())).thenReturn(true);
+        @Nested
+        @DisplayName("예외 시나리오")
+        class ExceptionTest {
 
-            // when & then
-            assertThatThrownBy(() -> memberService.createMember(signUpRequest))
-                    .isInstanceOf(MemberException.class).satisfies(exception -> {
-                        MemberException memberException = (MemberException) exception;
-                        assertThat(memberException.getErrorCode())
-                                .isEqualTo(MemberErrorCode.EMAIL_ALREADY_EXISTS);
-                    });
+            @Test
+            @DisplayName("존재하지 않는 memberId로 조회 시 MEMBER_NOT_FOUND 예외가 발생한다")
+            void getMemberDetailInfo_MemberNotFound() {
+                // given
+                Long nonExistentMemberId = 999L;
+                when(memberRepository.findById(nonExistentMemberId))
+                        .thenReturn(Optional.empty());
 
-            // verify
-            verify(memberRepository, times(1)).existsByEmail(signUpRequest.email());
-            verify(memberRepository, times(0)).save(any(Member.class)); // save는 호출되지 않아야 함
+                // when & then
+                assertThatThrownBy(() -> memberService
+                        .getMemberDetailInfo(nonExistentMemberId))
+                        .isInstanceOf(MemberException.class)
+                        .satisfies(exception -> {
+                            MemberException memberException =
+                                    (MemberException) exception;
+                            assertThat(memberException
+                                    .getErrorCode()).isEqualTo(
+                                    MemberErrorCode.MEMBER_NOT_FOUND);
+                        });
+
+                verify(memberRepository, times(1)).findById(nonExistentMemberId);
+            }
+
+            @Test
+            @DisplayName("null memberId로 조회 시 예외가 발생한다")
+            void getMemberDetailInfo_NullMemberId() {
+                // given
+                Long nullMemberId = null;
+                when(memberRepository.findById(nullMemberId))
+                        .thenReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberService
+                        .getMemberDetailInfo(nullMemberId))
+                        .isInstanceOf(MemberException.class)
+                        .satisfies(exception -> {
+                            MemberException memberException =
+                                    (MemberException) exception;
+                            assertThat(memberException
+                                    .getErrorCode()).isEqualTo(
+                                    MemberErrorCode.MEMBER_NOT_FOUND);
+                        });
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 변경 테스트")
+    class UpdateNicknameTest {
+
+        @Nested
+        @DisplayName("성공 시나리오")
+        class SuccessTest {
+
+            @Test
+            @DisplayName("정상적인 요청으로 닉네임을 변경할 수 있다")
+            void updateNickname_Success() {
+                // given
+                Long memberId = 1L;
+                String originalNickname = "기존닉네임";
+                String newNickname = "새로운닉네임";
+
+                Member member = Member.builder().name("홍길동")
+                        .nickname(originalNickname)
+                        .email("hong@example.com")
+                        .password("encrypted_password").build();
+
+                UpdateNicknameRequest request =
+                        new UpdateNicknameRequest(newNickname);
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                memberService.updateNickname(memberId, request);
+
+                // then
+                assertThat(member.getNickname()).isEqualTo(newNickname);
+                verify(memberRepository, times(1)).findById(memberId);
+            }
+
+            @Test
+            @DisplayName("다른 회원의 닉네임을 변경할 수 있다")
+            void updateNickname_DifferentMember() {
+                // given
+                Long memberId = 2L;
+                String newNickname = "철수의새닉네임";
+
+                Member member = Member.builder().name("김철수").nickname("철수")
+                        .email("chulsoo@example.com")
+                        .password("encrypted_password").build();
+
+                UpdateNicknameRequest request =
+                        new UpdateNicknameRequest(newNickname);
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                memberService.updateNickname(memberId, request);
+
+                // then
+                assertThat(member.getNickname()).isEqualTo(newNickname);
+                verify(memberRepository, times(1)).findById(memberId);
+            }
+
+            @Test
+            @DisplayName("여러 번 닉네임 변경이 정상적으로 작동한다")
+            void updateNickname_MultipleUpdates() {
+                // given
+                Long memberId = 1L;
+
+                Member member = Member.builder().name("홍길동").nickname("원래닉네임")
+                        .email("hong@example.com")
+                        .password("encrypted_password").build();
+
+                UpdateNicknameRequest request1 = new UpdateNicknameRequest("첫번째변경");
+                UpdateNicknameRequest request2 = new UpdateNicknameRequest("두번째변경");
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                memberService.updateNickname(memberId, request1);
+                memberService.updateNickname(memberId, request2);
+
+                // then
+                assertThat(member.getNickname()).isEqualTo("두번째변경");
+                verify(memberRepository, times(2)).findById(memberId);
+            }
         }
 
-        @Test
-        @DisplayName("이미 존재하는 이메일로 회원가입 시 예외 메시지가 올바르다")
-        void createMember_DuplicatedEmail_CorrectMessage() {
-            // given
-            when(memberRepository.existsByEmail(signUpRequest.email())).thenReturn(true);
+        @Nested
+        @DisplayName("예외 시나리오")
+        class ExceptionTest {
 
-            // when & then
-            assertThatThrownBy(() -> memberService.createMember(signUpRequest))
-                    .isInstanceOf(MemberException.class).hasMessage("이미 존재하는 이메일입니다.");
+            @Test
+            @DisplayName("존재하지 않는 memberId로 닉네임 변경 시 MEMBER_NOT_FOUND 예외가 발생한다")
+            void updateNickname_MemberNotFound() {
+                // given
+                Long nonExistentMemberId = 999L;
+                UpdateNicknameRequest request = new UpdateNicknameRequest("새닉네임");
+
+                when(memberRepository.findById(nonExistentMemberId))
+                        .thenReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberService
+                        .updateNickname(nonExistentMemberId, request))
+                        .isInstanceOf(MemberException.class)
+                        .satisfies(exception -> {
+                            MemberException memberException =
+                                    (MemberException) exception;
+                            assertThat(memberException
+                                    .getErrorCode()).isEqualTo(
+                                    MemberErrorCode.MEMBER_NOT_FOUND);
+                        });
+
+                verify(memberRepository, times(1)).findById(nonExistentMemberId);
+            }
+
+            @Test
+            @DisplayName("null memberId로 닉네임 변경 시 예외가 발생한다")
+            void updateNickname_NullMemberId() {
+                // given
+                Long nullMemberId = null;
+                UpdateNicknameRequest request = new UpdateNicknameRequest("새닉네임");
+
+                when(memberRepository.findById(nullMemberId))
+                        .thenReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberService.updateNickname(nullMemberId,
+                        request)).isInstanceOf(MemberException.class)
+                        .satisfies(exception -> {
+                            MemberException memberException =
+                                    (MemberException) exception;
+                            assertThat(memberException
+                                    .getErrorCode()).isEqualTo(
+                                    MemberErrorCode.MEMBER_NOT_FOUND);
+                        });
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호 변경 테스트")
+    class UpdatePasswordTest {
+
+        @Nested
+        @DisplayName("성공 시나리오")
+        class SuccessTest {
+
+            @Test
+            @DisplayName("정상적인 요청으로 비밀번호를 변경할 수 있다")
+            void updatePassword_Success() {
+                // given
+                Long memberId = 1L;
+                String originalPassword = "originalPassword123";
+                String newPassword = "newPassword456";
+
+                Member member = Member.builder().name("홍길동").nickname("길동이")
+                        .email("hong@example.com")
+                        .password(encryptor.encrypt(originalPassword))
+                        .build();
+
+                UpdatePasswordRequest request =
+                        new UpdatePasswordRequest(newPassword);
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                memberService.updatePassword(memberId, request);
+
+                // then
+                assertThat(encryptor.isMatch(newPassword, member.getPassword()))
+                        .isTrue();
+                assertThat(encryptor.isMatch(originalPassword,
+                        member.getPassword())).isFalse();
+                verify(memberRepository, times(1)).findById(memberId);
+            }
+
+            @Test
+            @DisplayName("다른 회원의 비밀번호를 변경할 수 있다")
+            void updatePassword_DifferentMember() {
+                // given
+                Long memberId = 2L;
+                String newPassword = "chulsooNewPassword789";
+
+                Member member = Member.builder().name("김철수").nickname("철수")
+                        .email("chulsoo@example.com")
+                        .password(encryptor.encrypt("oldPassword")).build();
+
+                UpdatePasswordRequest request =
+                        new UpdatePasswordRequest(newPassword);
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                memberService.updatePassword(memberId, request);
+
+                // then
+                assertThat(encryptor.isMatch(newPassword, member.getPassword()))
+                        .isTrue();
+                verify(memberRepository, times(1)).findById(memberId);
+            }
+
+            @Test
+            @DisplayName("비밀번호가 올바르게 암호화되어 저장된다")
+            void updatePassword_PasswordEncryption() {
+                // given
+                Long memberId = 1L;
+                String newPassword = "encryptionTest123";
+
+                Member member = Member.builder().name("홍길동").nickname("길동이")
+                        .email("hong@example.com")
+                        .password("oldEncryptedPassword").build();
+
+                UpdatePasswordRequest request =
+                        new UpdatePasswordRequest(newPassword);
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                memberService.updatePassword(memberId, request);
+
+                // then
+                // 평문 비밀번호가 그대로 저장되지 않았는지 확인
+                assertThat(member.getPassword()).isNotEqualTo(newPassword);
+                // 암호화된 비밀번호로 검증이 가능한지 확인
+                assertThat(encryptor.isMatch(newPassword, member.getPassword()))
+                        .isTrue();
+            }
+
+            @Test
+            @DisplayName("여러 번 비밀번호 변경이 정상적으로 작동한다")
+            void updatePassword_MultipleUpdates() {
+                // given
+                Long memberId = 1L;
+
+                Member member = Member.builder().name("홍길동").nickname("길동이")
+                        .email("hong@example.com")
+                        .password(encryptor.encrypt("originalPassword"))
+                        .build();
+
+                UpdatePasswordRequest request1 =
+                        new UpdatePasswordRequest("firstChange123");
+                UpdatePasswordRequest request2 =
+                        new UpdatePasswordRequest("secondChange456");
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                memberService.updatePassword(memberId, request1);
+                memberService.updatePassword(memberId, request2);
+
+                // then
+                assertThat(encryptor.isMatch("secondChange456",
+                        member.getPassword())).isTrue();
+                assertThat(encryptor.isMatch("firstChange123",
+                        member.getPassword())).isFalse();
+                assertThat(encryptor.isMatch("originalPassword",
+                        member.getPassword())).isFalse();
+                verify(memberRepository, times(2)).findById(memberId);
+            }
+
+            @Test
+            @DisplayName("같은 비밀번호로 변경해도 다른 해시값이 생성된다")
+            void updatePassword_SamePasswordDifferentHash() {
+                // given
+                Long memberId = 1L;
+                String samePassword = "samePassword123";
+
+                Member member = Member.builder().name("홍길동").nickname("길동이")
+                        .email("hong@example.com")
+                        .password(encryptor.encrypt("oldPassword")).build();
+
+                UpdatePasswordRequest request =
+                        new UpdatePasswordRequest(samePassword);
+
+                when(memberRepository.findById(memberId))
+                        .thenReturn(Optional.of(member));
+
+                // when
+                String firstHash = encryptor.encrypt(samePassword);
+                memberService.updatePassword(memberId, request);
+                String secondHash = member.getPassword();
+
+                // then
+                assertThat(encryptor.isMatch(samePassword, firstHash)).isTrue();
+                assertThat(encryptor.isMatch(samePassword, secondHash)).isTrue();
+                // BCrypt의 salt 특성으로 인해 같은 비밀번호라도 해시값이 다름
+                assertThat(firstHash).isNotEqualTo(secondHash);
+            }
         }
 
-        @Test
-        @DisplayName("서로 다른 이메일의 중복 검사가 독립적으로 작동한다")
-        void createMember_DifferentEmailsValidation() {
-            // given
-            SignUpRequest request1 =
-                    new SignUpRequest("김철수", "철수", "existing@example.com", "password1");
-            SignUpRequest request2 = new SignUpRequest("김영희", "영희", "new@example.com", "password2");
+        @Nested
+        @DisplayName("예외 시나리오")
+        class ExceptionTest {
 
-            // existing@example.com은 이미 존재, new@example.com은 존재하지 않음
-            when(memberRepository.existsByEmail("existing@example.com")).thenReturn(true);
-            when(memberRepository.existsByEmail("new@example.com")).thenReturn(false);
-            when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+            @Test
+            @DisplayName("존재하지 않는 memberId로 비밀번호 변경 시 MEMBER_NOT_FOUND 예외가 발생한다")
+            void updatePassword_MemberNotFound() {
+                // given
+                Long nonExistentMemberId = 999L;
+                UpdatePasswordRequest request =
+                        new UpdatePasswordRequest("newPassword123");
 
-            // when & then
-            // 첫 번째 요청은 예외 발생
-            assertThatThrownBy(() -> memberService.createMember(request1))
-                    .isInstanceOf(MemberException.class).satisfies(exception -> {
-                        MemberException memberException = (MemberException) exception;
-                        assertThat(memberException.getErrorCode())
-                                .isEqualTo(MemberErrorCode.EMAIL_ALREADY_EXISTS);
-                    });
+                when(memberRepository.findById(nonExistentMemberId))
+                        .thenReturn(Optional.empty());
 
-            // 두 번째 요청은 성공
-            SignUpResponse response = memberService.createMember(request2);
-            assertThat(response).isNotNull();
+                // when & then
+                assertThatThrownBy(() -> memberService
+                        .updatePassword(nonExistentMemberId, request))
+                        .isInstanceOf(MemberException.class)
+                        .satisfies(exception -> {
+                            MemberException memberException =
+                                    (MemberException) exception;
+                            assertThat(memberException
+                                    .getErrorCode()).isEqualTo(
+                                    MemberErrorCode.MEMBER_NOT_FOUND);
+                        });
 
-            // verify
-            verify(memberRepository, times(1)).existsByEmail("existing@example.com");
-            verify(memberRepository, times(1)).existsByEmail("new@example.com");
-            verify(memberRepository, times(1)).save(any(Member.class)); // 두 번째 요청에서만 save 호출
-        }
+                verify(memberRepository, times(1)).findById(nonExistentMemberId);
+            }
 
-        @Test
-        @DisplayName("null 이메일로 회원가입 시도 시 existsByEmail이 호출된다")
-        void createMember_NullEmail() {
-            // given
-            SignUpRequest nullEmailRequest = new SignUpRequest("홍길동", "길동", null, "password123");
-            when(memberRepository.existsByEmail(null)).thenReturn(false); // null에 대해서는 false 반환
-            when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+            @Test
+            @DisplayName("null memberId로 비밀번호 변경 시 예외가 발생한다")
+            void updatePassword_NullMemberId() {
+                // given
+                Long nullMemberId = null;
+                UpdatePasswordRequest request =
+                        new UpdatePasswordRequest("newPassword123");
 
-            // when
-            SignUpResponse response = memberService.createMember(nullEmailRequest);
+                when(memberRepository.findById(nullMemberId))
+                        .thenReturn(Optional.empty());
 
-            // then
-            assertThat(response).isNotNull();
-            verify(memberRepository, times(1)).existsByEmail(null);
-            verify(memberRepository, times(1)).save(any(Member.class));
-        }
-
-        @Test
-        @DisplayName("빈 문자열 이메일로 회원가입 시도 시 existsByEmail이 호출된다")
-        void createMember_EmptyEmail() {
-            // given
-            SignUpRequest emptyEmailRequest = new SignUpRequest("홍길동", "길동", "", "password123");
-            when(memberRepository.existsByEmail("")).thenReturn(false);
-            when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
-
-            // when
-            SignUpResponse response = memberService.createMember(emptyEmailRequest);
-
-            // then
-            assertThat(response).isNotNull();
-            verify(memberRepository, times(1)).existsByEmail("");
-            verify(memberRepository, times(1)).save(any(Member.class));
+                // when & then
+                assertThatThrownBy(() -> memberService.updatePassword(nullMemberId,
+                        request)).isInstanceOf(MemberException.class)
+                        .satisfies(exception -> {
+                            MemberException memberException =
+                                    (MemberException) exception;
+                            assertThat(memberException
+                                    .getErrorCode()).isEqualTo(
+                                    MemberErrorCode.MEMBER_NOT_FOUND);
+                        });
+            }
         }
     }
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- **작업 내용 요약:** 이 PR에서 해결하거나 추가한 내용을 간략히 설명해 주세요.
  - 사용자 상세 정보 조회 로직 구현
  - 사용자 닉네임 갱신 로직 구현
  - 사용자 비밀번호 갱신 로직 구현


# 🛠️ What’s been done?
## 수정사항
- `SignUpRequest`: 회원가입 요청 DTO에 Swagger 어노테이션 추가
- `Member`: 멤버 엔티티에 닉네임, 비밀번호 변경 메서드 추가
- `MemberSuccessCode`: 멤버 관련 성공 상태 코드에 새로운 코드 추가
## 기능 구현
- `MemberDetailInfo`: 멤버 상세 정보 응답 DTO
- `UpdateNicknameRequest`: 닉네임 갱신 요청 DTO
- `UpdatePasswordRequest`: 비밀번호 갱신 요청 DTO
- `MemberController`, `MemberService`
  - 사용자 상세정보 조회 로직 구현
  - 닉네임 변경 로직 구현
  - 비밀번호 변경 로직 구현

# 🧪 Testing Details

- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  추후 작성 후 PR 등록 예정


# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용


# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료
    없음


# 🎯 Related Issues

- 관련된 이슈를 연결하세요. (예: closes #이슈번호)
 #26 #27 