### PR TITLE
[test] 알림 전송 이벤트 및 AOP 테스트

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/aop/NotificationAspect.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/aop/NotificationAspect.java
@@ -28,12 +28,9 @@ public class NotificationAspect {
     private final NotificationEventPublisher notificationEventPublisher;
 
     /**
-     * NotificationService의 sendNotification 메서드에 대한 포인트컷 정의
-     * NotificationSendRequest를 파라미터로 받는 메서드를 대상으로 합니다.
+     * 주문 생성 서비스 로직을 수행하는 OrderService.createOrder를 대상으로 포인트 컷을 지정합니다.
      */
-    @Pointcut("execution(* git_kkalnane.backend.starbucks.notification.service" +
-            ".NotificationService" +
-            ".sendNotification(git_kkalnane.backend.starbucks.notification.dto.request.OrderNotificationSendRequest))")
+    @Pointcut("execution(* git_kkalnane.backend.starbucks.order.service.OrderService.createOrder(..))")
     public void notificationServiceMethods() {}
 
     /**

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/controller/NotificationController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/controller/NotificationController.java
@@ -68,15 +68,16 @@ public class NotificationController {
 
 
     @GetMapping(value = "/subscribe/status")
-    @Operation(summary = "멤버 알림 구독 현황 목록 조회"
-            , description = "멤버의 알림 구독 현황(SseEmitter) 목록을 조회합니다. 조회되지 않으면 빈 리스트를 반환합니다.")
+    @Operation(summary = "알림 구독 현황 목록 조회"
+            , description = "알림 구독 현황(SseEmitter) 목록을 조회합니다. 조회되지 않으면 빈 리스트를 반환합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "알림 구독 목록 조회 완료"
     )
-    public ResponseEntity<SuccessResponse<?>> fetchSubscribeList(@RequestAttribute Long memberId) {
+    public ResponseEntity<SuccessResponse<?>> fetchSubscribeList(@RequestAttribute Long memberId,
+                                                                @RequestParam String notificationTargetType) {
         return ResponseEntity.ok(SuccessResponse.of(
                 NotificationSuccessCode.NOTIFICATION_SUBSCRIPTION_RETRIEVED
-                , notificationService.getEmitters(memberId, NotificationTargetType.CUSTOMER)));
+                , notificationService.getEmitters(memberId, NotificationTargetType.findByName(notificationTargetType))));
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/domain/NotificationType.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/domain/NotificationType.java
@@ -21,6 +21,11 @@ public enum NotificationType {
     public String getTitle(Object ... args) {
         return title.formatted(args);
     }
+
+    public String getMessage() {
+        return message;
+    }
+
     public String getMessage(Object ... args) {
         return message.formatted(args);
     }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/domain/NotificationType.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/domain/NotificationType.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationType {
 
     SUBSCRIBE("알림 구독", "알림 구독이 완료되었습니다."),
-    ORDER_ACCEPTED("주문 접수 완료","%s님의 주문을 %s번째 메뉴로 준비 중입니다. (%s)"),
+    ORDER_ACCEPTED("주문 접수 완료","%s님의 주문을 준비 중입니다. (%s)"),
     ORDER_SET("메뉴 준비 완료","메뉴가 모두 준비되었어요. (%s) 픽업대에서 메뉴를 픽업해주세요!"),
     ORDER_CREATED("주문 발생", "새로운 주문이 발생했습니다."),
     ;
@@ -25,14 +25,6 @@ public enum NotificationType {
         return message.formatted(args);
     }
 
-    public static String getAppropriateMessage(NotificationType notificationType, Object ... args) {
-        return switch (notificationType) {
-            case ORDER_SET -> notificationType.getMessage(args[0]);
-            case ORDER_ACCEPTED -> notificationType.getMessage(args[0], args[1], args[2]);
-            default -> notificationType.getMessage();
-        };
-    }
-
     public static NotificationType findByName(String givenName){
         try{
             return NotificationType.valueOf(givenName.toUpperCase());
@@ -41,6 +33,5 @@ public enum NotificationType {
                 NotificationErrorCode.INVALID_NOTIFICATION_TYPE, givenName
             );
         }
-
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/dto/response/OrderNotificationSendBeverageItemResponse.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/dto/response/OrderNotificationSendBeverageItemResponse.java
@@ -2,23 +2,18 @@ package git_kkalnane.backend.starbucks.notification.dto.response;
 
 
 import git_kkalnane.backend.starbucks.item.domain.beverage.BeverageItem;
-import git_kkalnane.backend.starbucks.item.domain.beverage.BeverageItemSyrup;
 import lombok.Getter;
 
-import java.util.List;
 
 @Getter
 public class OrderNotificationSendBeverageItemResponse {
     private BeverageItem beverage;
-    private List<BeverageItemSyrup> syrups;
 
-
-    private OrderNotificationSendBeverageItemResponse(BeverageItem beverage, List<BeverageItemSyrup> syrups) {
+    private OrderNotificationSendBeverageItemResponse(BeverageItem beverage) {
         this.beverage = beverage;
-        this.syrups = syrups;
     }
 
     public static OrderNotificationSendBeverageItemResponse of(BeverageItem beverage) {
-        return new OrderNotificationSendBeverageItemResponse(beverage, beverage.getBeverageItemSyrup());
+        return new OrderNotificationSendBeverageItemResponse(beverage);
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/dto/response/OrderNotificationSendDessertItemResponse.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/dto/response/OrderNotificationSendDessertItemResponse.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 
 @Getter
 public class OrderNotificationSendDessertItemResponse {
-    private DessertItem beverage;
+    private DessertItem dessert;
 
-    private OrderNotificationSendDessertItemResponse(DessertItem beverage) {
-        this.beverage = beverage;
+    private OrderNotificationSendDessertItemResponse(DessertItem dessert) {
+        this.dessert = dessert;
     }
 
-    public static OrderNotificationSendDessertItemResponse of(DessertItem beverage) {
-        return new OrderNotificationSendDessertItemResponse(beverage);
+    public static OrderNotificationSendDessertItemResponse of(DessertItem dessert) {
+        return new OrderNotificationSendDessertItemResponse(dessert);
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/event/NotificationEventListener.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/event/NotificationEventListener.java
@@ -1,6 +1,8 @@
 package git_kkalnane.backend.starbucks.notification.event;
 
 
+import git_kkalnane.backend.starbucks._global.utils.GlobalLogger;
+import git_kkalnane.backend.starbucks.notification.domain.NotificationTargetType;
 import git_kkalnane.backend.starbucks.notification.domain.NotificationType;
 import git_kkalnane.backend.starbucks.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +34,8 @@ public class NotificationEventListener {
                 ),
                 event.getReceiver().value(),
                 event.getSender().value(),
-                event.getNotificationType(),
-                event.getNotificationTargetType()
+                NotificationType.ORDER_ACCEPTED,
+                NotificationTargetType.CUSTOMER
         );
 
         // 지점에게 주문 발생 알림 전송

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/service/NotificationService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package git_kkalnane.backend.starbucks.notification.service;
 
 
+import git_kkalnane.backend.starbucks._global.utils.GlobalLogger;
 import git_kkalnane.backend.starbucks.notification.common.success.NotificationSuccessCode;
 import git_kkalnane.backend.starbucks.notification.domain.*;
 import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationEvent;
@@ -57,8 +58,15 @@ public class NotificationService {
         SseEmitter emitter = emitterRepository.save(sseEmitterId, new SseEmitter(DEFAULT_TIMEOUT));
 
         // 클라이언트의 연결 종료 및 타임아웃에 대한 이벤트 처리 -> Emiiter 삭제
-        emitter.onCompletion(() -> emitterRepository.deleteById(sseEmitterId.getId()));
-        emitter.onTimeout(() -> emitterRepository.deleteById(sseEmitterId.getId()));
+        emitter.onCompletion(() -> {
+            GlobalLogger.info("SSE 연결 종료", "emitterId: " + sseEmitterId.getId());
+            emitterRepository.deleteById(sseEmitterId.getId());
+        });
+
+        emitter.onTimeout(() -> {
+            GlobalLogger.info("SSE 연결 종료", "emitterId: " + sseEmitterId.getId());
+            emitterRepository.deleteById(sseEmitterId.getId());
+        });
 
         // 503 에러를 방지하기 위한 구독용 더미 이벤트 전송
         NotificationEvent event = NotificationEvent.of
@@ -149,11 +157,12 @@ public class NotificationService {
         emitters.forEach(
                 (key, emitter) -> {
                     NotificationItemResponse<T> responseDto = notification.toDto(item);
-
-                    emitterRepository.saveEventCache(key, notification);
                     send(emitter, event, key, responseDto);
 
-                    emitterRepository.deleteById(key);
+                    if(notificationTargetType.equals(NotificationTargetType.CUSTOMER)
+                            && notificationType.equals(NotificationType.ORDER_SET)){
+                        emitter.complete();
+                    }
                 }
         );
 
@@ -200,10 +209,9 @@ public class NotificationService {
                     NotificationResponse responseDto = notification.toDto();
                     send(emitter, event, key, responseDto);
 
-                    // 주문완료 알림을 전송할 경우 receiver의 emitter를 삭제
-                    if(notification.getNotificationType().equals(NotificationType.ORDER_SET)){
+                    if(notificationTargetType.equals(NotificationTargetType.CUSTOMER)
+                            && notificationType.equals(NotificationType.ORDER_SET)){
                         emitter.complete();
-                        emitterRepository.deleteById(key);
                     }
                 }
         );
@@ -229,7 +237,7 @@ public class NotificationService {
 
         return sendNotification(
                 notificationType.getTitle(),
-                NotificationType.getAppropriateMessage(notificationType, order.getOrderNumber()),
+                notificationType.getMessage(order.getOrderNumber()),
                 // TODO: 현재는 주문 완료 메시지만 반환할 수 있음. 추후 리팩토링을 통해 코드를 분리할 수 있도록 수정
                 requestDto.getSenderId(),
                 requestDto.getReceiverId(),
@@ -248,14 +256,23 @@ public class NotificationService {
      */
     private void send(SseEmitter emitter, NotificationEvent event, String emitterId, Object data) {
         try {
-
+            GlobalLogger.info("SSE 전송 시작", "emitterId: " + emitterId + ", event: " + event.value() + ", data: " + data);
+            
             // TODO: emitter.send()는 동기작업으로 쓰레드를 블로킹한다. 다른 쓰레드에 작업을 할당하여 동기작업을 수행해야 한다.
             emitter.send(SseEmitter.event()
                     .id(event.value())
                     .name("sse")
                     .data(data)
             );
+            
+            GlobalLogger.info("SSE 전송 성공", "emitterId: " + emitterId);
+            
         } catch (IOException exception) {
+            GlobalLogger.error("SSE Emitter 전송 실패 - IOException", exception);
+            GlobalLogger.error("SSE 전송 실패 상세", "emitterId: " + emitterId + ", event: " + event.value() + ", error: " + exception.getMessage());
+        } catch (Exception exception) {
+            GlobalLogger.error("SSE Emitter 전송 실패 - 기타 예외", exception);
+            GlobalLogger.error("SSE 전송 실패 상세", "emitterId: " + emitterId + ", event: " + event.value() + ", error: " + exception.getMessage());
             emitterRepository.deleteById(emitterId);
         }
     }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/service/NotificationService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/notification/service/NotificationService.java
@@ -152,6 +152,8 @@ public class NotificationService {
 
                     emitterRepository.saveEventCache(key, notification);
                     send(emitter, event, key, responseDto);
+
+                    emitterRepository.deleteById(key);
                 }
         );
 
@@ -196,9 +198,13 @@ public class NotificationService {
         emitters.forEach(
                 (key, emitter) -> {
                     NotificationResponse responseDto = notification.toDto();
-
-                    emitterRepository.saveEventCache(key, notification);
                     send(emitter, event, key, responseDto);
+
+                    // 주문완료 알림을 전송할 경우 receiver의 emitter를 삭제
+                    if(notification.getNotificationType().equals(NotificationType.ORDER_SET)){
+                        emitter.complete();
+                        emitterRepository.deleteById(key);
+                    }
                 }
         );
 
@@ -242,6 +248,8 @@ public class NotificationService {
      */
     private void send(SseEmitter emitter, NotificationEvent event, String emitterId, Object data) {
         try {
+
+            // TODO: emitter.send()는 동기작업으로 쓰레드를 블로킹한다. 다른 쓰레드에 작업을 할당하여 동기작업을 수행해야 한다.
             emitter.send(SseEmitter.event()
                     .id(event.value())
                     .name("sse")

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/NotificationServiceTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/NotificationServiceTest.java
@@ -12,14 +12,20 @@ import git_kkalnane.backend.starbucks.notification.dto.request.OrderNotification
 import git_kkalnane.backend.starbucks.notification.dto.response.NotificationsResponse;
 import git_kkalnane.backend.starbucks.notification.repository.EmitterRepository;
 import git_kkalnane.backend.starbucks.notification.repository.NotificationRepository;
+import git_kkalnane.backend.starbucks.notification.repository.OrderNotificationRepository;
 import git_kkalnane.backend.starbucks.notification.service.NotificationService;
+import git_kkalnane.backend.starbucks.order.common.exception.OrderErrorCode;
+import git_kkalnane.backend.starbucks.order.common.exception.OrderException;
+import git_kkalnane.backend.starbucks.order.domain.Order;
+import git_kkalnane.backend.starbucks.order.repository.OrderRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +35,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -38,17 +45,23 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
     @Mock
     private EmitterRepository emitterRepository;
     @Mock
     private NotificationRepository notificationRepository;
+    @Mock
+    private OrderNotificationRepository orderNotificationRepository;
+    @Mock
+    private OrderRepository orderRepository;
+    
     @InjectMocks
     private NotificationService notificationService;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
+        // MockitoAnnotations.openMocks(this); // @ExtendWith(MockitoExtension.class)로 대체
     }
 
     @Nested
@@ -177,6 +190,15 @@ class NotificationServiceTest {
             OrderNotificationSendRequest request = new OrderNotificationSendRequest(
                     1L, 1L, 2L, "SUBSCRIBE", "CUSTOMER"
             );
+            
+            // Order Mock 설정
+            Order mockOrder = Order.builder()
+                    .id(1L)
+                    .orderNumber("ORDER-001")
+                    .orderTotalPrice(5000)
+                    .build();
+            
+            given(orderRepository.findById(request.getOrderId())).willReturn(Optional.of(mockOrder));
             given(emitterRepository.findAllEmitterStartWithByReceiverIdAndNotificationTargetType(anyLong(), any())).willReturn(Collections.emptyMap());
 
             // when
@@ -214,6 +236,22 @@ class NotificationServiceTest {
                     .isInstanceOf(NotificationException.class)
                     .hasMessageContaining(NotificationErrorCode.INVALID_NOTIFICATION_TYPE
                             .getMessage(request.getNotificationTargetType()));
+        }
+
+        @Test
+        @DisplayName("실패: 주문을 찾을 수 없음")
+        void sendNotification_orderNotFound() {
+            // given
+            OrderNotificationSendRequest request = new OrderNotificationSendRequest(
+                    999L, 1L, 2L, "SUBSCRIBE", "CUSTOMER"
+            );
+            
+            given(orderRepository.findById(request.getOrderId())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.sendNotification(request))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessageContaining(OrderErrorCode.ORDER_NOT_FOUND.getMessage());
         }
     }
 

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/aop/NotificationAspectUnitTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/aop/NotificationAspectUnitTest.java
@@ -1,0 +1,124 @@
+package git_kkalnane.backend.starbucks.notification.aop;
+
+import git_kkalnane.backend.starbucks.order.service.OrderService;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * NotificationAspect의 포인트컷 매칭을 단위 테스트하는 클래스
+ * Spring 컨텍스트를 로드하지 않고 순수하게 포인트컷 표현식만 테스트합니다.
+ */
+class NotificationAspectUnitTest {
+
+    private AspectJExpressionPointcut pointcut;
+
+    @BeforeEach
+    void setUp() {
+        pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression("execution(* git_kkalnane.backend.starbucks.order.service.OrderService.createOrder(..))");
+    }
+
+    @Test
+    @DisplayName("포인트컷 표현식이 올바른 형식인지 검증")
+    void 포인트컷_표현식_검증() {
+        // given & when
+        String expression = pointcut.getExpression();
+        
+        // then
+        assertThat(expression).isEqualTo("execution(* git_kkalnane.backend.starbucks.order.service.OrderService.createOrder(..))");
+    }
+
+    @Test
+    @DisplayName("NotificationAspect 클래스가 @Aspect 어노테이션을 가지고 있는지 검증")
+    void aspect_어노테이션_검증() {
+        // given & when
+        Class<NotificationAspect> aspectClass = NotificationAspect.class;
+        
+        // then
+        assertThat(aspectClass.isAnnotationPresent(Aspect.class)).isTrue();
+    }
+
+    @Test
+    @DisplayName("포인트컷이 다양한 메서드 시그니처에 대해 매칭되는지 테스트")
+    void 포인트컷_다양한_시그니처_매칭_테스트() throws NoSuchMethodException {
+        // given
+        Method[] methods = OrderService.class.getMethods();
+        
+        // when & then
+        for (Method method : methods) {
+            if ("createOrder".equals(method.getName())) {
+                assertThat(pointcut.matches(method, OrderService.class))
+                    .as("createOrder 메서드는 매칭되어야 합니다: " + method)
+                    .isTrue();
+            } else {
+                assertThat(pointcut.matches(method, OrderService.class))
+                    .as("createOrder가 아닌 메서드는 매칭되지 않아야 합니다: " + method)
+                    .isFalse();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("포인트컷이 다른 클래스의 메서드에는 매칭되지 않는지 테스트")
+    void 포인트컷_다른_클래스_매칭_실패_테스트() throws NoSuchMethodException {
+        // given
+        Method method = String.class.getMethod("length");
+        
+        // when
+        boolean matches = pointcut.matches(method, String.class);
+        
+        // then
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    @DisplayName("포인트컷 표현식의 각 부분이 올바른지 검증")
+    void 포인트컷_표현식_구성요소_검증() {
+        // given
+        String expression = "execution(* git_kkalnane.backend.starbucks.order.service.OrderService.createOrder(..))";
+        
+        // when & then
+        assertThat(expression)
+            .contains("execution")           // 실행 지점 지정
+            .contains("*")                   // 모든 반환 타입
+            .contains("git_kkalnane.backend.starbucks.order.service.OrderService")  // 대상 클래스
+            .contains("createOrder")         // 대상 메서드
+            .contains("(..)");               // 모든 매개변수
+    }
+
+    @Test
+    @DisplayName("NotificationAspect의 포인트컷 메서드가 올바르게 정의되어 있는지 검증")
+    void aspect_포인트컷_메서드_검증() throws NoSuchMethodException {
+        // given
+        Class<NotificationAspect> aspectClass = NotificationAspect.class;
+        
+        // when
+        Method pointcutMethod = aspectClass.getDeclaredMethod("notificationServiceMethods");
+        
+        // then
+        assertThat(pointcutMethod).isNotNull();
+        assertThat(pointcutMethod.isAnnotationPresent(org.aspectj.lang.annotation.Pointcut.class)).isTrue();
+    }
+
+    @Test
+    @DisplayName("NotificationAspect의 Advice 메서드가 올바르게 정의되어 있는지 검증")
+    void aspect_advice_메서드_검증() throws NoSuchMethodException {
+        // given
+        Class<NotificationAspect> aspectClass = NotificationAspect.class;
+        
+        // when
+        Method adviceMethod = aspectClass.getDeclaredMethod("orderAfter", 
+            git_kkalnane.backend.starbucks.order.domain.Order.class);
+        
+        // then
+        assertThat(adviceMethod).isNotNull();
+        assertThat(adviceMethod.isAnnotationPresent(org.aspectj.lang.annotation.AfterReturning.class)).isTrue();
+    }
+} 

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/event/NotificationEventListenerTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/event/NotificationEventListenerTest.java
@@ -1,0 +1,256 @@
+package git_kkalnane.backend.starbucks.notification.event;
+
+import git_kkalnane.backend.starbucks.member.domain.Member;
+import git_kkalnane.backend.starbucks.merchant.domain.Merchant;
+import git_kkalnane.backend.starbucks.notification.domain.NotificationTargetType;
+import git_kkalnane.backend.starbucks.notification.domain.NotificationType;
+import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationReceiver;
+import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationSender;
+import git_kkalnane.backend.starbucks.notification.dto.response.OrderNotificationSendResponse;
+import git_kkalnane.backend.starbucks.notification.service.NotificationService;
+import git_kkalnane.backend.starbucks.order.domain.Order;
+import git_kkalnane.backend.starbucks.order.domain.OrderItem;
+import git_kkalnane.backend.starbucks.order.domain.OrderStatus;
+import git_kkalnane.backend.starbucks.order.domain.PickupType;
+import git_kkalnane.backend.starbucks.store.domain.Store;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private NotificationEventListener notificationEventListener;
+
+    private Order mockOrder;
+    private Member mockMember;
+    @Mock
+    private Merchant mockMerchant;
+    private Store mockStore;
+    private OrderNotificationSendEvent mockEvent;
+
+    @BeforeEach
+    void setUp() {
+        // Given: 테스트용 도메인 객체들 생성
+        mockMember = Member.builder()
+                .id(1L)
+                .name("테스트 고객")
+                .nickname("테스트")
+                .email("test@test.com")
+                .password("password123")
+                .build();
+
+        // Merchant Mock 설정
+        when(mockMerchant.getId()).thenReturn(1L);
+
+        mockStore = Store.builder()
+                .id(1L)
+                .name("테스트 스토어")
+                .address("서울시 강남구")
+                .phone("02-1234-5678")
+                .merchant(mockMerchant)
+                .build();
+
+        mockOrder = Order.builder()
+                .id(1L)
+                .orderNumber("ORDER-001")
+                .orderTotalPrice(5000)
+                .orderStatus(OrderStatus.PLACED)
+                .pickupType(PickupType.STORE_PICKUP)
+                .orderRequestMemo("테스트 메모")
+                .orderExpectedPickupTime(LocalDateTime.now().plusMinutes(10))
+                .store(mockStore)
+                .member(mockMember)
+                .orderItems(new ArrayList<>())
+                .build();
+
+        // OrderItem 추가
+        OrderItem orderItem = OrderItem.builder()
+                .id(1L)
+                .itemName("아메리카노")
+                .orderItemQuantity(1)
+                .unitPrice(4500)
+                .order(mockOrder)
+                .build();
+        mockOrder.addOrderItem(orderItem);
+
+        mockEvent = new OrderNotificationSendEvent(
+                this,
+                mockOrder,
+                NotificationSender.of(mockMember.getId()),
+                NotificationReceiver.of(mockMerchant.getId()),
+                NotificationType.ORDER_CREATED,
+                NotificationTargetType.MERCHANT
+        );
+    }
+
+    @Nested
+    @DisplayName("handle() 메서드 테스트")
+    class HandleTest {
+
+        @Test
+        @DisplayName("성공: 주문 알림 이벤트 처리 시 고객과 매장 모두에게 알림 전송")
+        void handle_OrderNotificationEvent_SendsNotificationsToCustomerAndMerchant() {
+            // Given: 이벤트가 준비됨 (setUp에서 생성)
+
+            // When: 이벤트 리스너가 이벤트를 처리
+            notificationEventListener.handle(mockEvent);
+
+            // Then: 총 2번의 알림 전송이 발생함 (고객 1번, 매장 1번)
+            then(notificationService).should(times(2))
+                    .sendNotificationWithOrder(
+                            any(OrderNotificationSendResponse.class),
+                            anyString(),
+                            anyString(),
+                            anyLong(),
+                            anyLong(),
+                            any(NotificationType.class),
+                            any(NotificationTargetType.class)
+                    );
+        }
+
+        @Test
+        @DisplayName("성공: 고객에게 전송되는 알림 메시지가 올바른 형식으로 구성됨")
+        void handle_OrderNotificationEvent_CustomerNotificationHasCorrectMessageFormat() {
+            // Given: 이벤트가 준비됨
+
+            // When: 이벤트 리스너가 이벤트를 처리
+            notificationEventListener.handle(mockEvent);
+
+            // Then: 고객 알림 메시지가 올바른 형식으로 전송됨
+            then(notificationService).should(times(1))
+                    .sendNotificationWithOrder(
+                            any(OrderNotificationSendResponse.class),
+                            eq("주문 접수 완료"),
+                            eq(String.format("%s님의 주문을 준비 중입니다. (%s)", 
+                                    mockMember.getName(), 
+                                    mockOrder.getOrderNumber())),
+                            anyLong(),
+                            anyLong(),
+                            eq(NotificationType.ORDER_ACCEPTED),
+                            eq(NotificationTargetType.CUSTOMER)
+                    );
+        }
+
+        @Test
+        @DisplayName("성공: 매장에게 전송되는 알림이 이벤트의 원본 정보를 사용함")
+        void handle_OrderNotificationEvent_MerchantNotificationUsesOriginalEventData() {
+            // Given: 이벤트가 준비됨
+
+            // When: 이벤트 리스너가 이벤트를 처리
+            notificationEventListener.handle(mockEvent);
+
+            // Then: 매장 알림이 이벤트의 원본 정보를 사용함
+            then(notificationService).should(times(1))
+                    .sendNotificationWithOrder(
+                            any(OrderNotificationSendResponse.class),
+                            eq(mockEvent.getTitle()),
+                            eq(mockEvent.getMessage()),
+                            eq(mockEvent.getSender().value()),
+                            eq(mockEvent.getReceiver().value()),
+                            eq(mockEvent.getNotificationType()),
+                            eq(mockEvent.getNotificationTargetType())
+                    );
+        }
+
+        @Test
+        @DisplayName("성공: 두 개의 알림이 모두 OrderNotificationSendResponse와 함께 전송됨")
+        void handle_OrderNotificationEvent_BothNotificationsIncludeOrderResponseData() {
+            // Given: 이벤트가 준비됨
+
+            // When: 이벤트 리스너가 이벤트를 처리
+            notificationEventListener.handle(mockEvent);
+
+            // Then: 두 번의 sendNotificationWithOrder 호출이 모두 OrderNotificationSendResponse와 함께 이루어짐
+            then(notificationService).should(times(2))
+                    .sendNotificationWithOrder(
+                            any(OrderNotificationSendResponse.class),
+                            anyString(),
+                            anyString(),
+                            anyLong(),
+                            anyLong(),
+                            any(NotificationType.class),
+                            any(NotificationTargetType.class)
+                    );
+        }
+
+        @Test
+        @DisplayName("성공: 고객 알림과 매장 알림이 서로 다른 파라미터로 전송됨")
+        void handle_OrderNotificationEvent_CustomerAndMerchantNotificationsHaveDifferentParameters() {
+            // Given: 이벤트가 준비됨
+
+            // When: 이벤트 리스너가 이벤트를 처리
+            notificationEventListener.handle(mockEvent);
+
+            // Then: 고객 알림 (첫 번째 호출)
+            then(notificationService).should(times(1))
+                    .sendNotificationWithOrder(
+                            any(OrderNotificationSendResponse.class),
+                            eq("주문 접수 완료"),
+                            eq(String.format("%s님의 주문을 준비 중입니다. (%s)", 
+                                    mockMember.getName(), 
+                                    mockOrder.getOrderNumber())),
+                            eq(mockEvent.getReceiver().value()), // merchantId
+                            eq(mockEvent.getSender().value()),   // memberId
+                            eq(NotificationType.ORDER_ACCEPTED),
+                            eq(NotificationTargetType.CUSTOMER)
+                    );
+
+            // Then: 매장 알림 (두 번째 호출)
+            then(notificationService).should(times(1))
+                    .sendNotificationWithOrder(
+                            any(OrderNotificationSendResponse.class),
+                            eq(mockEvent.getTitle()),
+                            eq(mockEvent.getMessage()),
+                            eq(mockEvent.getSender().value()),   // memberId
+                            eq(mockEvent.getReceiver().value()), // merchantId
+                            eq(mockEvent.getNotificationType()),
+                            eq(mockEvent.getNotificationTargetType())
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("비동기 처리 테스트")
+    class AsyncProcessingTest {
+
+        @Test
+        @DisplayName("성공: @Async 어노테이션으로 인해 비동기로 처리됨")
+        void handle_OrderNotificationEvent_ProcessedAsynchronously() {
+            // Given: 이벤트가 준비됨
+
+            // When: 이벤트 리스너가 이벤트를 처리 (비동기로 실행됨)
+            notificationEventListener.handle(mockEvent);
+
+            // Then: 메서드가 정상적으로 호출됨 (비동기 실행이므로 즉시 반환)
+            // 실제 비동기 테스트는 별도의 통합 테스트에서 수행
+            then(notificationService).should(times(2))
+                    .sendNotificationWithOrder(
+                            any(OrderNotificationSendResponse.class),
+                            anyString(),
+                            anyString(),
+                            anyLong(),
+                            anyLong(),
+                            any(NotificationType.class),
+                            any(NotificationTargetType.class)
+                    );
+        }
+    }
+} 

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/event/NotificationEventPublisherTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/event/NotificationEventPublisherTest.java
@@ -1,0 +1,268 @@
+package git_kkalnane.backend.starbucks.notification.event;
+
+import git_kkalnane.backend.starbucks.member.domain.Member;
+import git_kkalnane.backend.starbucks.merchant.domain.Merchant;
+import git_kkalnane.backend.starbucks.notification.domain.NotificationTargetType;
+import git_kkalnane.backend.starbucks.notification.domain.NotificationType;
+import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationReceiver;
+import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationSender;
+import git_kkalnane.backend.starbucks.order.domain.Order;
+import git_kkalnane.backend.starbucks.order.domain.OrderItem;
+import git_kkalnane.backend.starbucks.order.domain.OrderStatus;
+import git_kkalnane.backend.starbucks.order.domain.PickupType;
+import git_kkalnane.backend.starbucks.store.domain.Store;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventPublisherTest {
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @InjectMocks
+    private NotificationEventPublisher notificationEventPublisher;
+
+    private Order mockOrder;
+    private Member mockMember;
+    @Mock
+    private Merchant mockMerchant;
+    private Store mockStore;
+    private OrderNotificationSendEvent mockEvent;
+
+    @BeforeEach
+    void setUp() {
+        // Given: 테스트용 도메인 객체들 생성
+        mockMember = Member.builder()
+                .id(1L)
+                .name("테스트 고객")
+                .nickname("테스트")
+                .email("test@test.com")
+                .password("password123")
+                .build();
+
+        // Merchant Mock 설정
+        when(mockMerchant.getId()).thenReturn(1L);
+
+        mockStore = Store.builder()
+                .id(1L)
+                .name("테스트 스토어")
+                .address("서울시 강남구")
+                .phone("02-1234-5678")
+                .merchant(mockMerchant)
+                .build();
+
+        mockOrder = Order.builder()
+                .id(1L)
+                .orderNumber("ORDER-001")
+                .orderTotalPrice(5000)
+                .orderStatus(OrderStatus.PLACED)
+                .pickupType(PickupType.STORE_PICKUP)
+                .orderRequestMemo("테스트 메모")
+                .orderExpectedPickupTime(LocalDateTime.now().plusMinutes(10))
+                .store(mockStore)
+                .member(mockMember)
+                .orderItems(new ArrayList<>())
+                .build();
+
+        // OrderItem 추가
+        OrderItem orderItem = OrderItem.builder()
+                .id(1L)
+                .itemName("아메리카노")
+                .orderItemQuantity(1)
+                .unitPrice(4500)
+                .order(mockOrder)
+                .build();
+        mockOrder.addOrderItem(orderItem);
+
+        mockEvent = new OrderNotificationSendEvent(
+                this,
+                mockOrder,
+                NotificationSender.of(mockMember.getId()),
+                NotificationReceiver.of(mockMerchant.getId()),
+                NotificationType.ORDER_CREATED,
+                NotificationTargetType.MERCHANT
+        );
+    }
+
+    @Nested
+    @DisplayName("publish() 메서드 테스트")
+    class PublishTest {
+
+        @Test
+        @DisplayName("성공: OrderNotificationSendEvent 이벤트를 정상적으로 발행함")
+        void publish_OrderNotificationSendEvent_PublishesEventSuccessfully() {
+            // Given: OrderNotificationSendEvent가 준비됨 (setUp에서 생성)
+
+            // When: 이벤트 퍼블리셔가 이벤트를 발행
+            notificationEventPublisher.publish(mockEvent);
+
+            // Then: ApplicationEventPublisher가 이벤트를 발행함
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(mockEvent);
+        }
+
+        @Test
+        @DisplayName("성공: 여러 번의 이벤트 발행이 모두 정상적으로 처리됨")
+        void publish_MultipleEvents_PublishesAllEventsSuccessfully() {
+            // Given: 여러 개의 이벤트가 준비됨
+            OrderNotificationSendEvent event1 = new OrderNotificationSendEvent(
+                    this,
+                    mockOrder,
+                    NotificationSender.of(1L),
+                    NotificationReceiver.of(2L),
+                    NotificationType.ORDER_CREATED,
+                    NotificationTargetType.MERCHANT
+            );
+
+            OrderNotificationSendEvent event2 = new OrderNotificationSendEvent(
+                    this,
+                    mockOrder,
+                    NotificationSender.of(2L),
+                    NotificationReceiver.of(1L),
+                    NotificationType.ORDER_ACCEPTED,
+                    NotificationTargetType.CUSTOMER
+            );
+
+            // When: 여러 이벤트를 연속으로 발행
+            notificationEventPublisher.publish(event1);
+            notificationEventPublisher.publish(event2);
+
+            // Then: 모든 이벤트가 발행됨
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(event1);
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(event2);
+        }
+
+        @Test
+        @DisplayName("성공: null 이벤트가 전달되어도 예외 없이 처리됨")
+        void publish_NullEvent_HandlesGracefully() {
+            // Given: null 이벤트가 준비됨
+            OrderNotificationSendEvent nullEvent = null;
+
+            // When: null 이벤트를 발행
+            notificationEventPublisher.publish(nullEvent);
+
+            // Then: ApplicationEventPublisher가 null 이벤트를 발행함
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(null);
+        }
+
+        @Test
+        @DisplayName("성공: 다른 타입의 이벤트도 정상적으로 발행됨")
+        void publish_DifferentEventTypes_PublishesAllEventTypesSuccessfully() {
+            // Given: 다양한 알림 타입의 이벤트들이 준비됨
+            OrderNotificationSendEvent orderCreatedEvent = new OrderNotificationSendEvent(
+                    this,
+                    mockOrder,
+                    NotificationSender.of(1L),
+                    NotificationReceiver.of(2L),
+                    NotificationType.ORDER_CREATED,
+                    NotificationTargetType.MERCHANT
+            );
+
+            OrderNotificationSendEvent orderAcceptedEvent = new OrderNotificationSendEvent(
+                    this,
+                    mockOrder,
+                    NotificationSender.of(2L),
+                    NotificationReceiver.of(1L),
+                    NotificationType.ORDER_ACCEPTED,
+                    NotificationTargetType.CUSTOMER
+            );
+
+            OrderNotificationSendEvent orderSetEvent = new OrderNotificationSendEvent(
+                    this,
+                    mockOrder,
+                    NotificationSender.of(1L),
+                    NotificationReceiver.of(1L),
+                    NotificationType.ORDER_SET,
+                    NotificationTargetType.CUSTOMER
+            );
+
+            // When: 다양한 타입의 이벤트들을 발행
+            notificationEventPublisher.publish(orderCreatedEvent);
+            notificationEventPublisher.publish(orderAcceptedEvent);
+            notificationEventPublisher.publish(orderSetEvent);
+
+            // Then: 모든 이벤트가 발행됨
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(orderCreatedEvent);
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(orderAcceptedEvent);
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(orderSetEvent);
+        }
+    }
+
+    @Nested
+    @DisplayName("의존성 주입 테스트")
+    class DependencyInjectionTest {
+
+        @Test
+        @DisplayName("성공: ApplicationEventPublisher가 정상적으로 주입됨")
+        void publish_WithInjectedDependency_UsesInjectedApplicationEventPublisher() {
+            // Given: 이벤트가 준비됨
+
+            // When: 이벤트를 발행
+            notificationEventPublisher.publish(mockEvent);
+
+            // Then: 주입된 ApplicationEventPublisher가 사용됨
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(any(OrderNotificationSendEvent.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("이벤트 발행 순서 테스트")
+    class EventPublishingOrderTest {
+
+        @Test
+        @DisplayName("성공: 이벤트 발행 순서가 호출 순서와 일치함")
+        void publish_EventsInOrder_PublishesInCorrectOrder() {
+            // Given: 순서가 있는 이벤트들이 준비됨
+            OrderNotificationSendEvent firstEvent = new OrderNotificationSendEvent(
+                    this,
+                    mockOrder,
+                    NotificationSender.of(1L),
+                    NotificationReceiver.of(2L),
+                    NotificationType.ORDER_CREATED,
+                    NotificationTargetType.MERCHANT
+            );
+
+            OrderNotificationSendEvent secondEvent = new OrderNotificationSendEvent(
+                    this,
+                    mockOrder,
+                    NotificationSender.of(2L),
+                    NotificationReceiver.of(1L),
+                    NotificationType.ORDER_ACCEPTED,
+                    NotificationTargetType.CUSTOMER
+            );
+
+            // When: 순서대로 이벤트를 발행
+            notificationEventPublisher.publish(firstEvent);
+            notificationEventPublisher.publish(secondEvent);
+
+            // Then: 순서대로 발행됨 (Mockito의 verify 순서 확인)
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(firstEvent);
+            then(applicationEventPublisher).should(times(1))
+                    .publishEvent(secondEvent);
+        }
+    }
+} 

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/event/OrderNotificationSendEventTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/notification/event/OrderNotificationSendEventTest.java
@@ -1,0 +1,266 @@
+package git_kkalnane.backend.starbucks.notification.event;
+
+import git_kkalnane.backend.starbucks.member.domain.Member;
+import git_kkalnane.backend.starbucks.merchant.domain.Merchant;
+import git_kkalnane.backend.starbucks.notification.domain.NotificationTargetType;
+import git_kkalnane.backend.starbucks.notification.domain.NotificationType;
+import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationReceiver;
+import git_kkalnane.backend.starbucks.notification.domain.vo.NotificationSender;
+import git_kkalnane.backend.starbucks.notification.dto.response.OrderNotificationSendResponse;
+import git_kkalnane.backend.starbucks.order.domain.Order;
+import git_kkalnane.backend.starbucks.order.domain.OrderItem;
+import git_kkalnane.backend.starbucks.order.domain.OrderStatus;
+import git_kkalnane.backend.starbucks.order.domain.PickupType;
+import git_kkalnane.backend.starbucks.store.domain.Store;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderNotificationSendEventTest {
+    private Order mockOrder;
+    private Member mockMember;
+    @Mock
+    private Merchant mockMerchant;
+    private Store mockStore;
+    private OrderNotificationSendEvent event;
+
+    @BeforeEach
+    void setUp() {
+        // Given: 테스트용 도메인 객체들 생성
+        mockMember = Member.builder()
+                .id(1L)
+                .name("테스트 고객")
+                .nickname("테스트")
+                .email("test@test.com")
+                .password("password123")
+                .build();
+
+        // Merchant Mock 설정
+        when(mockMerchant.getId()).thenReturn(1L);
+
+        mockStore = Store.builder()
+                .id(1L)
+                .name("테스트 스토어")
+                .address("서울시 강남구")
+                .phone("02-1234-5678")
+                .merchant(mockMerchant)
+                .build();
+
+        mockOrder = Order.builder()
+                .id(1L)
+                .orderNumber("ORDER-001")
+                .orderTotalPrice(5000)
+                .orderStatus(OrderStatus.PLACED)
+                .pickupType(PickupType.STORE_PICKUP)
+                .orderRequestMemo("테스트 메모")
+                .orderExpectedPickupTime(LocalDateTime.now().plusMinutes(10))
+                .store(mockStore)
+                .member(mockMember)
+                .orderItems(new ArrayList<>())
+                .build();
+
+        OrderItem orderItem = OrderItem.builder()
+                .id(1L)
+                .itemName("아메리카노")
+                .orderItemQuantity(1)
+                .unitPrice(4500)
+                .order(mockOrder)
+                .build();
+        mockOrder.addOrderItem(orderItem);
+
+        event = new OrderNotificationSendEvent(
+                this,
+                mockOrder,
+                NotificationSender.of(mockMember.getId()),
+                NotificationReceiver.of(mockMerchant.getId()),
+                NotificationType.ORDER_CREATED,
+                NotificationTargetType.MERCHANT
+        );
+    }
+
+    @Nested
+    @DisplayName("OrderNotificationSendResponse 변환 테스트")
+    class OrderNotificationSendResponseTest {
+        @Test
+        @DisplayName("OrderNotificationSendEvent_Item_변환_정상")
+        void item_ConvertedToOrderNotificationSendResponseCorrectly() {
+            // When
+            OrderNotificationSendResponse item = event.getItem();
+            // Then
+            assertThat(item).isNotNull();
+            assertThat(item.getOrderId()).isEqualTo(mockOrder.getId());
+            assertThat(item.getOrderNumber()).isEqualTo(mockOrder.getOrderNumber());
+            assertThat(item.getPickupType()).isEqualTo(mockOrder.getPickupType());
+            assertThat(item.getOrderRequestMemo()).isEqualTo(mockOrder.getOrderRequestMemo());
+            assertThat(item.getOrderExpectedPickupTime()).isEqualTo(mockOrder.getOrderExpectedPickupTime());
+            assertThat(item.getStoreId()).isEqualTo(mockOrder.getStore().getId());
+            assertThat(item.getMemberId()).isEqualTo(mockOrder.getMember().getId());
+            assertThat(item.getMemberName()).isEqualTo(mockOrder.getMember().getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 타입별 생성 테스트")
+    class NotificationTypeTest {
+        @Test
+        @DisplayName("OrderNotificationSendEvent_ORDER_ACCEPTED_생성_정상")
+        void constructor_OrderAcceptedType_CreatesEventSuccessfully() {
+            // When
+            OrderNotificationSendEvent acceptedEvent = new OrderNotificationSendEvent(
+                    this,
+                    mockOrder,
+                    NotificationSender.of(mockMember.getId()),
+                    NotificationReceiver.of(mockMerchant.getId()),
+                    NotificationType.ORDER_ACCEPTED,
+                    NotificationTargetType.CUSTOMER
+            );
+            // Then
+            assertThat(acceptedEvent).isNotNull();
+            assertThat(acceptedEvent.getNotificationType()).isEqualTo(NotificationType.ORDER_ACCEPTED);
+            assertThat(acceptedEvent.getTitle()).isEqualTo(NotificationType.ORDER_ACCEPTED.getTitle());
+            assertThat(acceptedEvent.getMessage()).isEqualTo(NotificationType.ORDER_ACCEPTED.getMessage());
+        }
+        @Test
+        @DisplayName("OrderNotificationSendEvent_ORDER_SET_생성_정상")
+        void constructor_OrderSetType_CreatesEventSuccessfully() {
+            // When
+            OrderNotificationSendEvent setEvent = new OrderNotificationSendEvent(
+                    this,
+                    mockOrder,
+                    NotificationSender.of(mockMember.getId()),
+                    NotificationReceiver.of(mockMerchant.getId()),
+                    NotificationType.ORDER_SET,
+                    NotificationTargetType.CUSTOMER
+            );
+            // Then
+            assertThat(setEvent).isNotNull();
+            assertThat(setEvent.getNotificationType()).isEqualTo(NotificationType.ORDER_SET);
+            assertThat(setEvent.getTitle()).isEqualTo(NotificationType.ORDER_SET.getTitle());
+            assertThat(setEvent.getMessage()).isEqualTo(NotificationType.ORDER_SET.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 아이템 처리 테스트")
+    class OrderItemProcessingTest {
+        @Test
+        @DisplayName("OrderNotificationSendEvent_음료아이템_포함_정상처리")
+        void orderWithBeverageItem_ProcessesCorrectly() {
+            // Given
+            Order orderWithBeverage = Order.builder()
+                    .id(2L)
+                    .orderNumber("ORDER-002")
+                    .orderTotalPrice(4500)
+                    .orderStatus(OrderStatus.PLACED)
+                    .pickupType(PickupType.STORE_PICKUP)
+                    .orderRequestMemo("음료 주문")
+                    .orderExpectedPickupTime(LocalDateTime.now().plusMinutes(10))
+                    .store(mockStore)
+                    .member(mockMember)
+                    .orderItems(new ArrayList<>())
+                    .build();
+            OrderItem beverageItem = OrderItem.builder()
+                    .id(2L)
+                    .itemName("카페라떼")
+                    .orderItemQuantity(1)
+                    .unitPrice(5000)
+                    .order(orderWithBeverage)
+                    .build();
+            orderWithBeverage.addOrderItem(beverageItem);
+            // When
+            OrderNotificationSendEvent beverageEvent = new OrderNotificationSendEvent(
+                    this,
+                    orderWithBeverage,
+                    NotificationSender.of(mockMember.getId()),
+                    NotificationReceiver.of(mockMerchant.getId()),
+                    NotificationType.ORDER_CREATED,
+                    NotificationTargetType.MERCHANT
+            );
+            // Then
+            assertThat(beverageEvent).isNotNull();
+            assertThat(beverageEvent.getItem()).isNotNull();
+            assertThat(beverageEvent.getItem().getOrderId()).isEqualTo(orderWithBeverage.getId());
+        }
+        @Test
+        @DisplayName("OrderNotificationSendEvent_디저트아이템_포함_정상처리")
+        void orderWithDessertItem_ProcessesCorrectly() {
+            // Given
+            Order orderWithDessert = Order.builder()
+                    .id(3L)
+                    .orderNumber("ORDER-003")
+                    .orderTotalPrice(3500)
+                    .orderStatus(OrderStatus.PLACED)
+                    .pickupType(PickupType.STORE_PICKUP)
+                    .orderRequestMemo("디저트 주문")
+                    .orderExpectedPickupTime(LocalDateTime.now().plusMinutes(10))
+                    .store(mockStore)
+                    .member(mockMember)
+                    .orderItems(new ArrayList<>())
+                    .build();
+            OrderItem dessertItem = OrderItem.builder()
+                    .id(3L)
+                    .itemName("티라미수")
+                    .orderItemQuantity(1)
+                    .unitPrice(3500)
+                    .order(orderWithDessert)
+                    .build();
+            orderWithDessert.addOrderItem(dessertItem);
+            // When
+            OrderNotificationSendEvent dessertEvent = new OrderNotificationSendEvent(
+                    this,
+                    orderWithDessert,
+                    NotificationSender.of(mockMember.getId()),
+                    NotificationReceiver.of(mockMerchant.getId()),
+                    NotificationType.ORDER_CREATED,
+                    NotificationTargetType.MERCHANT
+            );
+            // Then
+            assertThat(dessertEvent).isNotNull();
+            assertThat(dessertEvent.getItem()).isNotNull();
+            assertThat(dessertEvent.getItem().getOrderId()).isEqualTo(orderWithDessert.getId());
+        }
+        @Test
+        @DisplayName("OrderNotificationSendEvent_빈주문아이템_정상처리")
+        void orderWithEmptyItems_CreatesEventSuccessfully() {
+            // Given
+            Order emptyOrder = Order.builder()
+                    .id(4L)
+                    .orderNumber("ORDER-004")
+                    .orderTotalPrice(0)
+                    .orderStatus(OrderStatus.PLACED)
+                    .pickupType(PickupType.STORE_PICKUP)
+                    .orderRequestMemo("빈 주문")
+                    .orderExpectedPickupTime(LocalDateTime.now().plusMinutes(10))
+                    .store(mockStore)
+                    .member(mockMember)
+                    .orderItems(new ArrayList<>())
+                    .build();
+            // When
+            OrderNotificationSendEvent emptyEvent = new OrderNotificationSendEvent(
+                    this,
+                    emptyOrder,
+                    NotificationSender.of(mockMember.getId()),
+                    NotificationReceiver.of(mockMerchant.getId()),
+                    NotificationType.ORDER_CREATED,
+                    NotificationTargetType.MERCHANT
+            );
+            // Then
+            assertThat(emptyEvent).isNotNull();
+            assertThat(emptyEvent.getItem()).isNotNull();
+            assertThat(emptyEvent.getItem().getOrderId()).isEqualTo(emptyOrder.getId());
+            assertThat(emptyEvent.getItem().getBeverageItems()).isEmpty();
+            assertThat(emptyEvent.getItem().getDessertItems()).isEmpty();
+        }
+    }
+} 


### PR DESCRIPTION
# 🚀 What’s this PR about?

- **작업 내용 요약:**
  - 알림 전송 이벤트 및 AOP 테스트

# 🛠️ What’s been done?

- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  - 알림 전송 이벤트 및 AOP 테스트 코드 작성

# 🧪 Testing Details

- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
`/notification` 폴더의 테스트 내용을 확인해보겠습니다.

 **1. NotificationServiceTest.java**
- **목적**: 알림 서비스의 핵심 기능 테스트
- **주요 테스트 케이스**:
  - `subscribe()`: SSE 구독 기능 (정상 구독, 잘못된 타입 처리)
  - `fetchNotificationsByMemberId()`: 알림 목록 조회 (정상 조회, 빈 목록 처리)
  - `sendNotification()`: 알림 전송 (정상 전송, 예외 처리)
  - `getEmitters()`: Emitter 목록 조회

**2. NotificationAspectUnitTest.java** (새로 생성)
- **목적**: AOP 포인트컷 매칭 단위 테스트
- **주요 테스트 케이스**:
  - 포인트컷 표현식 검증
  - `@Aspect` 어노테이션 검증
  - 다양한 메서드 시그니처 매칭 테스트
  - 다른 클래스 메서드 매칭 실패 테스트
  - 포인트컷 표현식 구성요소 검증
  - Aspect 메서드 정의 검증

**3. NotificationEventListenerTest.java**
- **목적**: 알림 이벤트 리스너 테스트
- **주요 테스트 케이스**:
  - 주문 알림 이벤트 처리 (고객/매장 양방향 알림)
  - 알림 메시지 형식 검증
  - 이벤트 원본 정보 사용 검증
  - 비동기 처리 검증

**4. OrderNotificationSendEventTest.java**
- **목적**: 주문 알림 이벤트 객체 테스트
- **주요 테스트 케이스**:
  - `OrderNotificationSendResponse` 변환 테스트
  - 알림 타입별 생성 테스트 (`ORDER_ACCEPTED`, `ORDER_SET`)
  - 주문 아이템 처리 테스트 (음료, 디저트, 빈 아이템)

**5. NotificationEventPublisherTest.java**
- **목적**: 이벤트 발행기 테스트
- **주요 테스트 케이스**:
  - 이벤트 정상 발행
  - 다중 이벤트 발행
  - null 이벤트 처리
  - 다양한 이벤트 타입 발행
  - 의존성 주입 검증
  
# 👀 Checkpoints for Reviewers
추가적으로 수행해야 할 테스트가 있는지 확인 부탁드립니다.

# 🎯 Related Issues
#98 
