### PR TITLE
[feat] 매장 주문 상태 변경 구현

### DIFF
--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/common/exception/OrderErrorCode.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/common/exception/OrderErrorCode.java
@@ -12,7 +12,8 @@ public enum OrderErrorCode implements ErrorCode {
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 주문을 찾을 수 없습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 매장을 찾을 수 없습니다."),
-    FORBIDDEN_ACCESS_ORDER(HttpStatus.FORBIDDEN, "해당 주문에 접근할 권한이 없습니다.");
+    FORBIDDEN_ACCESS_ORDER(HttpStatus.FORBIDDEN, "해당 주문에 접근할 권한이 없습니다."),
+    CANNOT_UPDATE_COMPLETED_ORDER(HttpStatus.BAD_REQUEST, "이미 완료되거나 취소된 주문의 상태는 변경할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/common/success/OrderSuccessCode.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/common/success/OrderSuccessCode.java
@@ -10,7 +10,8 @@ public enum OrderSuccessCode implements SuccessCode {
     ORDER_DETAIL_VIEWED(HttpStatus.OK, "주문 상세 정보 조회가 성공했습니다."),
     ORDER_CURRENT_VIEWED(HttpStatus.OK, "현재 진행중인 주문 목록 조회가 성공했습니다."),
     STORE_ORDER_DETAIL_VIEWED(HttpStatus.OK, "매장 주문 상세 정보 조회 성공"),
-    STORE_ORDERS_VIEWED(HttpStatus.OK, "매장의 현재 주문 목록 조회가 성공했습니다.");
+    STORE_ORDERS_VIEWED(HttpStatus.OK, "매장의 현재 주문 목록 조회가 성공했습니다."),
+    ORDER_STATUS_UPDATED(HttpStatus.OK, "주문 상태가 성공적으로 변경되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/controller/OrderController.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/controller/OrderController.java
@@ -3,6 +3,7 @@ package git_kkalnane.backend.starbucks.order.controller;
 import git_kkalnane.backend.starbucks._global.success.SuccessResponse;
 import git_kkalnane.backend.starbucks.order.common.success.OrderSuccessCode;
 import git_kkalnane.backend.starbucks.order.domain.Order;
+import git_kkalnane.backend.starbucks.order.dto.request.StoreOrderStatusUpdateRequest;
 import git_kkalnane.backend.starbucks.order.dto.response.CurrentOrderResponse;
 import git_kkalnane.backend.starbucks.order.dto.response.OrderDetailResponse;
 import git_kkalnane.backend.starbucks.order.dto.response.OrderListResponse;
@@ -132,5 +133,28 @@ public class OrderController {
 
         return ResponseEntity
                 .ok(SuccessResponse.of(OrderSuccessCode.STORE_ORDERS_VIEWED, result));
+    }
+
+    /**
+     * [매장용 API] 특정 주문의 상태를 변경합니다. (예: 접수 -> 준비중)
+     *
+     * // TODO: 추후 Auth 로직 구현 시, @AuthenticationPrincipal을 사용하도록 변경.
+     *
+     * @param storeId           상태를 변경할 주문이 속한 매장의 ID (임시로 URL 경로에서 받습니다)
+     * @param orderId           상태를 변경할 주문의 ID
+     * @param request           새로운 주문 상태를 담은 DTO
+     * @return 성공 응답
+     */
+    @PatchMapping("/store/{storeId}/{orderId}/status") // 임시
+    public ResponseEntity<SuccessResponse> updateOrderStatus(
+            @PathVariable Long storeId, // 임시
+            @PathVariable Long orderId,
+            @Valid @RequestBody StoreOrderStatusUpdateRequest request
+    ) {
+
+        orderService.updateOrderStatus(storeId, orderId, request.newStatus());
+
+        return ResponseEntity
+                .ok(SuccessResponse.of(OrderSuccessCode.ORDER_STATUS_UPDATED));
     }
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/Order.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/Order.java
@@ -61,4 +61,8 @@ public class Order extends BaseTimeEntity {
         item.setOrder(this);
     }
 
+    public void updateStatus(OrderStatus newStatus) {
+        this.orderStatus = newStatus;
+    }
+
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/OrderStatus.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/domain/OrderStatus.java
@@ -5,5 +5,5 @@ public enum OrderStatus {
     PREPARING,
     READY_FOR_PICKUP,
     COMPLETED,
-    CANCELLED
+    CANCELED
 }

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/request/StoreOrderStatusUpdateRequest.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/dto/request/StoreOrderStatusUpdateRequest.java
@@ -1,0 +1,16 @@
+package git_kkalnane.backend.starbucks.order.dto.request;
+
+import git_kkalnane.backend.starbucks.order.domain.OrderStatus;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 매장에서 주문 상태 변경을 요청할 때 사용하는 DTO (Data Transfer Object).
+ * Java Record를 사용하여 불변 객체로 정의합니다.
+ *
+ * @param newStatus 변경하고자 하는 새로운 주문 상태 (PREPARING, READY_FOR_PICKUP, CANCELED 등)
+ */
+public record StoreOrderStatusUpdateRequest (
+        @NotNull(message = "변경할 주문 상태는 필수입니다.")
+        OrderStatus newStatus
+) {
+}

--- a/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/service/OrderService.java
+++ b/starbucks/src/main/java/git_kkalnane/backend/starbucks/order/service/OrderService.java
@@ -250,4 +250,27 @@ public class OrderService {
         return order;
 
     }
+
+    /**
+     * 매장의 특정 주문 상태를 변경합니다.
+     *
+     * @param storeId   요청한 매장의 ID (권한 검증용)
+     * @param orderId   상태를 변경할 주문의 ID
+     * @param newStatus 변경할 새로운 주문 상태
+     */
+    @Transactional
+    public void updateOrderStatus(Long storeId, Long orderId, OrderStatus newStatus) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getStore().getId().equals(storeId)) {
+            throw new OrderException(OrderErrorCode.FORBIDDEN_ACCESS_ORDER);
+        }
+
+        if (order.getOrderStatus() == OrderStatus.COMPLETED || order.getOrderStatus() == OrderStatus.CANCELED) {
+            throw new OrderException(OrderErrorCode.CANNOT_UPDATE_COMPLETED_ORDER);
+        }
+
+        order.updateStatus(newStatus);
+    }
 }

--- a/starbucks/src/test/java/git_kkalnane/backend/starbucks/order/OrderServiceTest.java
+++ b/starbucks/src/test/java/git_kkalnane/backend/starbucks/order/OrderServiceTest.java
@@ -440,4 +440,89 @@ class OrderServiceTest {
                 .isInstanceOf(OrderException.class)
                 .hasMessageContaining("해당 주문에 접근할 권한이 없습니다.");
     }
+
+    @Test
+    @DisplayName("주문 상태 변경 - 성공")
+    void updateOrderStatus_Success() {
+        Long storeId = 1L;
+        Long orderId = 10L;
+        OrderStatus newStatus = OrderStatus.PREPARING;
+
+        Store mockStore = mock(Store.class);
+        given(mockStore.getId()).willReturn(storeId);
+
+        Order mockOrder = mock(Order.class);
+        given(mockOrder.getStore()).willReturn(mockStore);
+        given(mockOrder.getOrderStatus()).willReturn(OrderStatus.PLACED);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(mockOrder));
+
+        // when
+        orderService.updateOrderStatus(storeId, orderId, newStatus);
+
+        // then
+        verify(mockOrder, times(1)).updateStatus(newStatus);
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 - 실패 (다른 매장 주문)")
+    void updateOrderStatus_Fail_ForbiddenAccess() {
+        // given
+        Long myStoreId = 1L;
+        Long anotherStoreId = 2L;
+        Long orderId = 10L;
+        OrderStatus newStatus = OrderStatus.PREPARING;
+
+        Store anotherStore = mock(Store.class);
+        given(anotherStore.getId()).willReturn(anotherStoreId);
+
+        Order mockOrder = mock(Order.class);
+        given(mockOrder.getStore()).willReturn(anotherStore);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(mockOrder));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.updateOrderStatus(myStoreId, orderId, newStatus))
+                .isInstanceOf(OrderException.class)
+                .hasMessageContaining("해당 주문에 접근할 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 - 실패 (이미 완료된 주문)")
+    void updateOrderStatus_Fail_AlreadyCompleted() {
+        // given
+        Long storeId = 1L;
+        Long orderId = 10L;
+        OrderStatus newStatus = OrderStatus.PREPARING;
+
+        Store mockStore = mock(Store.class);
+        given(mockStore.getId()).willReturn(storeId);
+
+        Order mockOrder = mock(Order.class);
+        given(mockOrder.getStore()).willReturn(mockStore);
+        given(mockOrder.getOrderStatus()).willReturn(OrderStatus.COMPLETED);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(mockOrder));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.updateOrderStatus(storeId, orderId, newStatus))
+                .isInstanceOf(OrderException.class)
+                .hasMessageContaining("이미 완료되거나 취소된 주문의 상태는 변경할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 - 실패 (존재하지 않는 주문)")
+    void updateOrderStatus_Fail_OrderNotFound() {
+        // given
+        Long storeId = 1L;
+        Long nonExistentOrderId = 999L;
+        OrderStatus newStatus = OrderStatus.PREPARING;
+
+        given(orderRepository.findById(nonExistentOrderId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.updateOrderStatus(storeId, nonExistentOrderId, newStatus))
+                .isInstanceOf(OrderException.class)
+                .hasMessageContaining("요청하신 주문을 찾을 수 없습니다.");
+    }
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 매장 관리자가 주문을 접수하고 처리 상태(예: 주문 접수 -> 준비 중)를 변경할 수 있는 API 기능을 구현했습니다.

# 🛠️ What’s been done?

- DTO 정의
  - StoreOrderStatusUpdateRequest DTO를 Java record로 정의하여, 클라이언트로부터 변경할 새로운 주문 상태(newStatus)를 받도록 했습니다. @NotNull을 통해 유효성 검사를 추가했습니다.

- 서비스 로직(OrderService) 구현
  - updateOrderStatus 메서드를 구현했습니다. 이 메서드는 아래의 핵심 검증 로직을 포함합니다.
  - 권한 검증: 요청한 매장이 해당 주문에 대한 변경 권한이 있는지 확인합니다.
  - 상태 검증: 이미 '완료'되거나 '취소'된 주문의 상태는 변경할 수 없도록 방어 로직을 추가했습니다.

- 컨트롤러 엔드포인트(OrderController) 추가
  - PATCH /api/v1/orders/store/{storeId}/{orderId}/status 엔드포인트를 추가했습니다.

- 에러 및 성공 코드 추가
  - OrderErrorCode에 CANNOT_UPDATE_COMPLETED_ORDER를 추가하여 상태 변경 불가 시 명확한 에러를 반환합니다.
  - OrderSuccessCode에 ORDER_STATUS_UPDATED를 추가하여 성공 응답 메시지를 통일했습니다.

# 🧪 Testing Details
![image](https://github.com/user-attachments/assets/bcb4aeeb-7c78-4262-bbb3-fdd278cac1a0)
- 테스트 코드 및 결과:
  - 단위 테스트: OrderService의 updateOrderStatus 메서드에 대해 단위 테스트를 작성했습니다. 아래의 모든 시나리오에 대한 검증을 완료했습니다.

  - 상태 변경 성공 케이스
  - 권한 없음 실패 케이스 (다른 매장 주문)
  - 상태 변경 불가 실패 케이스 (완료된 주문)
  - 주문 없음 실패 케이스 (존재하지 않는 주문)

작성된 모든 단위 테스트는 성공적으로 통과하는 것을 확인했습니다.

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

- closes #168 